### PR TITLE
Render markdown properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Reqtraq has 3 main components:
 
 ## How to install Reqtraq
 ### Dependencies
-  * go 1.8+
-
-Install Go according to the instructions [here](https://golang.org/doc/install)
+  * go 1.8+ *Installation instructions [here](https://golang.org/doc/install).*
+  * pandoc *Installation instructions [here](https://pandoc.org/installing.html).*
 
 
 ### Installation

--- a/certdocs/0-DDLN-211-SRD.md
+++ b/certdocs/0-DDLN-211-SRD.md
@@ -201,6 +201,16 @@ The report generation tool SHALL have a simple web interface that allows generat
 - Verification: Demonstration
 - Safety impact: None
 
+##### REQ-0-DDLN-SWH-014 Requirement Rich Formatting
+
+The RMT SHALL allow for us to express rich markdown concepts in requirements descriptions, e.g. math, tables, and code.
+
+###### Attributes:
+- Rationale: Technical Requiments often need to document equations, tables of data, or code.
+- Parents: REQ-0-DDLN-SYS-006
+- Verification: Demonstration
+- Safety impact: None
+
 ### Other Assumptions
 
 In the creation of these requirements it was assumed that Reqtraq users use Git for version control.

--- a/certdocs/0-DDLN-212-SDD.md
+++ b/certdocs/0-DDLN-212-SDD.md
@@ -433,6 +433,52 @@ Attributes can be optional or mandatory. Each attribute has a name. Each attribu
 - Verification: Demonstration
 - Safety impact: None
 
+##### REQ-0-DDLN-SWL-019 Pandoc markdown rendering
+
+The RMT tool SHALL invoke pandoc to convert markdown (and pandoc extensions like math, tables, and code) into HTML that correctly renders into generated reports.
+
+* Requirements bodies can include code that is delimited with the triple-backtick delimiter (\```), which results in rendered HTML as follows:
+```
+int main(int argc, char** argv) {
+        FlyAirplane();
+}
+```
+
+
+* Requirements bodies can include math (both inline and display) that is delimited with the single dollar sign (\$) for inline, and the double dollar
+sign (\$$) for display. They will be rendered in HTML reports using MathJax and look as follows:
+    * Inline math: $x=y$
+    * Display math:
+$$
+\frac{d}{dx}\left( \int_{0}^{x} f(u)\,du\right)=f(x).
+$$
+
+* Requirements bodies can include tables in any of the four pandoc table formats. An example simple table is shown here:
+
+--------------------------------------------------------------------
+             *Alpha*         *Beta*              *Gamma*
+----------   -------------   -----------------   --------------------
+    Monday     3 Watts        2 pints             3 chickens,  
+                                                  1 hr at charger
+
+   Tuesday    14 Kilograms    1 Penguin,          1 cheese sandwich
+                              2 Thunderbird
+
+ Wednesday    2 aspirin       Tall space ship    (can't remember)
+---------------------------------------------------------------------
+
+Table:  *Table of nonsense*, deluxe edition
+
+
+
+
+###### Attributes:
+- Rationale: pandoc is a markdown to HTML converter that has markdown-extensions for math, tables, and code.
+- Parents: REQ-0-DDLN-SWH-014
+- Verification: Demonstration
+- Safety impact: None
+
+
 ### Other Assumptions
 
 In the creation of these requirements it was assumed that Reqtraq users use Git for version control.

--- a/diff.go
+++ b/diff.go
@@ -86,7 +86,7 @@ func (r *Req) ChangedSince(pr *Req) (diffs []string) {
 		// only bother with the bodies if the titles are the same
 		// compare modulo spaces and punctuation, ie only the letters
 
-		if onlyLetters(r.Body) != onlyLetters(pr.Body) {
+		if onlyLetters(string(r.Body)) != onlyLetters(string(pr.Body)) {
 			diffs = append(diffs, fmt.Sprintf("Body changed"))
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -276,7 +276,7 @@ func main() {
 				continue
 			}
 			body := make([]string, 0)
-			lines := strings.Split(r.Body, "\n")
+			lines := strings.Split(string(r.Body), "\n")
 			for _, line := range lines {
 				if line == "" {
 					continue

--- a/parsing.go
+++ b/parsing.go
@@ -24,6 +24,7 @@ var (
 	reReqKWD     = regexp.MustCompile(`(?i)(- )?(rationale|parent|parents|safety impact|verification|urgent|important|mode|provenance):`)
 )
 
+// @llr REQ-0-DDLN-SWL-019
 // Given a string containing markdown, convert it to HTML using pandoc
 func formatBodyAsHTML(txt string) (template.HTML) {
 	cmd := exec.Command("pandoc", "--mathjax")

--- a/parsing.go
+++ b/parsing.go
@@ -34,8 +34,6 @@ func formatBodyAsHTML(txt string) (template.HTML) {
 
 	go func() {
 		defer stdin.Close()
-		// TODO(aroetter): remove this
-		//txt = "Hello some text *bold* more text **more**."
 		io.WriteString(stdin, txt)
 	}()
 

--- a/parsing.go
+++ b/parsing.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"unicode"
@@ -38,6 +39,7 @@ var (
 //
 // Since the parsing is rather 'soft', ParseReq returns verbose errors indicating problems in
 // a helpful way, meaning they at least provide enough context for the user to find the text.
+// TODO(aroetter): pass in a bool pandoc here
 func ParseReq(txt string) (*Req, error) {
 	lyx := strings.HasPrefix(txt, "\n")
 	head := txt
@@ -121,7 +123,10 @@ func ParseReq(txt string) (*Req, error) {
 
 	parts := strings.SplitN(strings.TrimSpace(txt), "\n", 2)
 	r.Title = parts[0]
+	// TODO(aroetter): Run this body text through pandoc
 	r.Body = parts[1]
+	r.Body = "ALEX says hello, look at the body text now. <b>Bold</b>."
+	log.Println("ALEX2 got a body [", r.Body, "]")
 
 	return r, nil
 }

--- a/parsing.go
+++ b/parsing.go
@@ -147,7 +147,6 @@ func ParseReq(txt string) (*Req, error) {
 
 	parts := strings.SplitN(strings.TrimSpace(txt), "\n", 2)
 	r.Title = parts[0]
-
 	r.Body = formatBodyAsHTML(parts[1])
 	return r, nil
 }

--- a/parsing.go
+++ b/parsing.go
@@ -39,7 +39,6 @@ var (
 //
 // Since the parsing is rather 'soft', ParseReq returns verbose errors indicating problems in
 // a helpful way, meaning they at least provide enough context for the user to find the text.
-// TODO(aroetter): pass in a bool pandoc here
 func ParseReq(txt string) (*Req, error) {
 	lyx := strings.HasPrefix(txt, "\n")
 	head := txt

--- a/parsing.go
+++ b/parsing.go
@@ -3,7 +3,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"html/template"
 	"regexp"
 	"strings"
 	"unicode"
@@ -124,9 +124,6 @@ func ParseReq(txt string) (*Req, error) {
 	parts := strings.SplitN(strings.TrimSpace(txt), "\n", 2)
 	r.Title = parts[0]
 	// TODO(aroetter): Run this body text through pandoc
-	r.Body = parts[1]
-	r.Body = "ALEX says hello, look at the body text now. <b>Bold</b>."
-	log.Println("ALEX2 got a body [", r.Body, "]")
-
+	r.Body = template.HTML(parts[1])
 	return r, nil
 }

--- a/report.go
+++ b/report.go
@@ -107,6 +107,11 @@ var reportTmpl = template.Must(template.New("").Parse(`
 				text-decoration: none;
 			}
 		</style>
+		<!-- Load MathJax for rending of equations -->
+		<script type="text/javascript" async
+			src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+		</script>
+
 	</head>
 	<body>
 		<section style="max-width:100%; text-align:center;">

--- a/report.go
+++ b/report.go
@@ -107,7 +107,7 @@ var reportTmpl = template.Must(template.New("").Parse(`
 				text-decoration: none;
 			}
 		</style>
-		<!-- Load MathJax for rending of equations -->
+		<!-- Load MathJax for rendering of equations -->
 		<script type="text/javascript" async
 			src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 		</script>

--- a/req.go
+++ b/req.go
@@ -503,7 +503,8 @@ func (rg reqGraph) UpdateTasks(filterIDs map[string]bool) error {
 				if !currentReq.IsDeleted() {
 					log.Printf("Creating task for requirement %s", currentReq.ID)
 
-					taskPHID, err := taskmgr.TaskMgr.CreateTask(currentReq.ID+": "+currentReq.Title, currentReq.Body, projectPHID, currentReq.Attributes, parentTaskIDs)
+					taskPHID, err := taskmgr.TaskMgr.CreateTask(currentReq.ID+": "+currentReq.Title, string(currentReq.Body),
+						projectPHID, currentReq.Attributes, parentTaskIDs)
 					if err != nil {
 						return fmt.Errorf("Error creating requirement %s, caused by\n%v", currentReq.ID, err)
 					}
@@ -521,7 +522,8 @@ func (rg reqGraph) UpdateTasks(filterIDs map[string]bool) error {
 					}
 				} else {
 					log.Printf("Updating task T%s for requirement %s", task.ID, currentReq.ID)
-					err = taskmgr.TaskMgr.UpdateTask(task.ID, currentReq.ID+": "+currentReq.Title, currentReq.Body, projectPHID, currentReq.Attributes, parentTaskIDs)
+					err = taskmgr.TaskMgr.UpdateTask(task.ID, currentReq.ID+": "+currentReq.Title, string(currentReq.Body),
+						projectPHID, currentReq.Attributes, parentTaskIDs)
 					if err != nil {
 						return fmt.Errorf("Error updating requirement %s, caused by\n%v", currentReq.ID, err)
 					}
@@ -645,7 +647,7 @@ func (r *Req) Matches(filter ReqFilter, diffs map[string][]string) bool {
 				return false
 			}
 		case BodyFilter:
-			if !e.MatchString(r.Body) {
+			if !e.MatchString(string(r.Body)) {
 				return false
 			}
 		}

--- a/req.go
+++ b/req.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"crypto/sha1"
 	"fmt"
+	"html/template"
 	"io"
 	"io/ioutil"
 	"log"
@@ -59,7 +60,9 @@ type Req struct {
 	Parents    []*Req
 	Children   []*Req
 	Title      string
-	Body       string
+	// Body contains various HTML tags (links, converted markup, etc). Type must be HTML,
+	// not a string, so it's not HTML-escaped by the template.
+	Body       template.HTML
 	Attributes map[string]string
 	Position   int
 	Seen       bool

--- a/req.go
+++ b/req.go
@@ -60,8 +60,8 @@ type Req struct {
 	Parents    []*Req
 	Children   []*Req
 	Title      string
-	// Body contains various HTML tags (links, converted markup, etc). Type must be HTML,
-	// not a string, so it's not HTML-escaped by the template.
+	// Body contains various HTML tags (links, converted markdown, etc). Type must be HTML,
+	// not a string, so it's not HTML-escaped by the templating engine.
 	Body       template.HTML
 	Attributes map[string]string
 	Position   int


### PR DESCRIPTION
Use pandoc to take the body and convert the markdown to HTML.

This fixes existing presentation bugs where markdown/links/code snippets don't render correctly in the HTML reports.

But it also allows us to use pandoc extension to markdown, e.g. LaTeX math, tables, etc.

See REQ-0-DDLN-SQL-019 in the generated reports to see examples of all of these in action.