### PR TITLE
Fix precommit to not validate previous

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,7 +216,9 @@ func main() {
 			log.Fatal(err)
 		}
 		defer os.RemoveAll(dir)
-
+	}
+	switch command {
+	case "reportdown", "reportup", "reportissues":
 		var prg *reqGraph
 		if *since != "" {
 			var dir string


### PR DESCRIPTION
precommit was validating both the latest and the previous,
while it should check only the latest.