### PR TITLE
Speed up calls to list, nextid, precommit and prepush by deferring ht…

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -86,7 +86,7 @@ func (r *Req) ChangedSince(pr *Req) (diffs []string) {
 		// only bother with the bodies if the titles are the same
 		// compare modulo spaces and punctuation, ie only the letters
 
-		if onlyLetters(string(r.Body)) != onlyLetters(string(pr.Body)) {
+		if onlyLetters(r.Body) != onlyLetters(pr.Body) {
 			diffs = append(diffs, fmt.Sprintf("Body changed"))
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -252,7 +252,7 @@ func main() {
 				continue
 			}
 			body := make([]string, 0)
-			lines := strings.Split(string(r.Body), "\n")
+			lines := strings.Split(r.Body, "\n")
 			for _, line := range lines {
 				if line == "" {
 					continue

--- a/parsing.go
+++ b/parsing.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"fmt"
-	"html/template"
-	"io"
-	"log"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -24,28 +20,6 @@ var (
 	reAttributesSectionHeading = regexp.MustCompile(`(?m)\n#{2,6} Attributes:$`)
 	reReqKWD                   = regexp.MustCompile(`(?i)- ([^:]+): `)
 )
-
-// formatBodyAsHTML converts a string containing markdown to HTML using pandoc.
-// @llr REQ-TRAQ-SWL-19
-func formatBodyAsHTML(txt string) template.HTML {
-	cmd := exec.Command("pandoc", "--mathjax")
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		log.Fatal("Couldn't get input pipe for pandoc: ", err)
-	}
-
-	go func() {
-		defer stdin.Close()
-		io.WriteString(stdin, txt)
-	}()
-
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Fatal("Error while running pandoc: ", err)
-	}
-
-	return template.HTML(out)
-}
 
 // ParseReq finds the first REQ-XXX tag and the reserved words and distills a Req from it.
 //
@@ -144,8 +118,9 @@ func ParseReq(txt string) (*Req, error) {
 		}
 	}
 
-	r.Body = formatBodyAsHTML(bodyAndAttributes[:attributesStart])
-	if strings.TrimSpace(string(r.Body)) == "" {
+	r.Body = bodyAndAttributes[:attributesStart]
+
+	if strings.TrimSpace(r.Body) == "" {
 		return nil, fmt.Errorf("Requirement body must not be empty: %s", r.ID)
 	}
 

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -20,7 +20,7 @@ body
 	assert.Nil(t, err)
 	assert.Equal(t, "REQ-TEST-SWL-1", r.ID)
 	assert.Equal(t, "title", r.Title)
-	assert.Equal(t, "<p>body</p>\n<p>body</p>\n", string(r.Body))
+	assert.Equal(t, "body\n\nbody\n", r.Body)
 	assert.Equal(t, "This is why.", r.Attributes["RATIONALE"])
 	assert.Equal(t, "exists", r.Attributes["ATTRIBUTE WHICH WILL NEVER EXIST"])
 	assert.Equal(t, []string{"REQ-TEST-SYS-1"}, r.ParentIds)
@@ -58,7 +58,7 @@ body
 	assert.Nil(t, err)
 	assert.Equal(t, "REQ-TEST-SWL-1", r.ID)
 	assert.Equal(t, "DELETED Some title", r.Title)
-	assert.Equal(t, "<p>body</p>\n", string(r.Body))
+	assert.Equal(t, "body\n", r.Body)
 	assert.Equal(t, "This is why.", r.Attributes["RATIONALE"])
 	assert.Equal(t, []string{"REQ-TEST-SYS-1"}, r.ParentIds)
 	assert.True(t, r.IsDeleted())
@@ -88,7 +88,7 @@ func TestParseReq_NoAttributes(t *testing.T) {
 	r, err := ParseReq(`REQ-TEST-SWL-1 title
 body`)
 	assert.Nil(t, err)
-	assert.Equal(t, "<p>body</p>\n", string(r.Body))
+	assert.Equal(t, "body", r.Body)
 }
 
 func TestParseReq_EmptyAttributesSection(t *testing.T) {

--- a/req.go
+++ b/req.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"html/template"
 	"io/ioutil"
 	"log"
 	"os"
@@ -59,9 +58,7 @@ type Req struct {
 	// Tags holds the associated code functions.
 	Tags  []*Code
 	Title string
-	// Body contains various HTML tags (links, converted markdown, etc). Type must be HTML,
-	// not a string, so it's not HTML-escaped by the templating engine.
-	Body template.HTML
+	Body  string
 	// Attributes of the requirement by uppercase name.
 	Attributes map[string]string
 	Position   int
@@ -562,7 +559,7 @@ func (r *Req) Matches(filter *ReqFilter, diffs map[string][]string) bool {
 			}
 		}
 		if filter.BodyRegexp != nil {
-			if !filter.BodyRegexp.MatchString(string(r.Body)) {
+			if !filter.BodyRegexp.MatchString(r.Body) {
 				return false
 			}
 		}


### PR DESCRIPTION
…ml conversion to when reports are generated

The func parsing::formatBodyAsHTML uses external cmd pandoc to format requirement body text to html, because it's done once per requirement then as the number of requirements increases the total execution time got quite large. I've moved the conversion so that it's done when the report html files are generated and not when the requirements are parsed because it's not needed for commands list, nextid, precommit or prepush.