### PR TITLE
Update to markdown parsing to read requirements from tables in additi…

### DIFF
--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -449,7 +449,7 @@ The command must be executed in the repository for which the reports will be gen
 - Safety impact: None
 
 
-##### REQ-TRAQ-SWL-21 Requirement definition detection
+##### REQ-TRAQ-SWL-21 Requirement definition detection (ATX heading)
 
 Reqtraq SHALL discover requirements definitions in certification documents `.md` files by detecting the beginning and end:
   - a requirement starts with an [ATX heading](https://github.github.com/gfm/#atx-headings) which has at the beginning a requirement ID
@@ -462,7 +462,7 @@ Reqtraq SHALL discover requirements definitions in certification documents `.md`
 - Safety impact: None
 
 
-##### REQ-TRAQ-SWL-13 Requirement attributes
+##### REQ-TRAQ-SWL-13 Requirement attributes (ATX heading)
 
 The RMT SHALL read the attributes of each requirement from the attributes section at the end of the requirement definition. The attributes section starts with an [ATX heading](https://github.github.com/gfm/#atx-headings) with the title "Attributes:". Since attributes belong to a requirement, the attribute ATX heading level will be higher than the containing requirement heading level. For example, a requirement defined with an ATX heading level of 3 will have attributes with ATX heading level 4 or higher.
 
@@ -480,6 +480,39 @@ Attributes can be optional or mandatory. Each attribute has a name. Each attribu
   { "name": "Verification", "value": "(Demonstration|Unit Test)", "optional": false },
   { "name": "Safety Impact", "optional": false } ] }
 ```
+
+###### Attributes:
+- Rationale: Attributes help define the importance of and the verification process for each requirement. Missing attributes indicate an incomplete requirement.
+- Parents: REQ-TRAQ-SWH-11
+- Verification: Demonstration
+- Safety impact: None
+
+
+##### REQ-TRAQ-SWL-24 Requirement definition detection (tables)
+
+Reqtraq SHALL discover requirements definitions held in [tables]( https://github.github.com/gfm/#tables-extension-) in certification documents `.md` files by detecting the beginning and end:
+  - a requirement table starts with a header row where the first column has the text "ID"
+  - a requirement table ends when a non-table row is encountered.
+
+###### Attributes:
+- Rationale: Using existing markdown elements is preferable to introducing new syntax
+- Parents: REQ-TRAQ-SWH-1
+- Verification: Unit test
+- Safety impact: None
+
+
+##### REQ-TRAQ-SWL-25 Requirement attributes (tables)
+
+The RMT SHALL read the attributes of each requirement held in a requirement table from each column of the table. The first row of the table contains the attribute name for each column, the first column being "ID" to represent requirement ID. The second row is a delimiter. The third row onward contains the requirement ID and associated attribute text as shown:
+
+> | ID | Title | Body | Attribute1 | Attribute2 |
+> | --- | --- | --- | --- | --- |
+> | ReqID1 | <text> | <text> | <text> | <text> |
+> | ReqID2 | <text> | <text> | <text> | <text> |
+
+
+As with ATX headings, attributes can be optional or mandatory as specified in the `attributes.json` file.
+
 
 ###### Attributes:
 - Rationale: Attributes help define the importance of and the verification process for each requirement. Missing attributes indicate an incomplete requirement.

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,7 @@ func TestPreCommitCreateReqGraphMarkdown(t *testing.T) {
 	expected := `Incorrect requirement type for requirement REQ-TEST-SWH-3. Expected SYS, got SWH.
 Incorrect project abbreviation for requirement REQ-TSET-SYS-5. Expected TEST, got TSET.
 Invalid requirement sequence number for REQ-TEST-SYS-1, is duplicate.
-Invalid requirement sequence number for REQ-TEST-SYS-13: missing requirements in between. Total number of requirements is 10.
+Invalid requirement sequence number for REQ-TEST-SYS-13: missing requirements in between. Expected ID Number 9.
 Requirement number cannot begin with a 0: REQ-TEST-SWL-04. Got 04.
 Requirement REQ-TEST-SWH-6 in file /testdata/TestPreCommitCreateReqGraphMarkdown/TEST-137-SRD.md has no parents.
 Invalid parent of requirement REQ-TEST-SWH-9: REQ-TEST-SYS-3 does not exist.

--- a/parsing.go
+++ b/parsing.go
@@ -1,3 +1,14 @@
+/*
+Functions within this file are concerned with parsing requirements out of markdown documents.
+
+The entry point is ParseCertdoc which in turns calls other functions as follows:
+- ParseCertdoc: Checks filename is valid then calls:
+- parseMarkdown: Scans file one line at a time looking for requirements that either formatted within ATX headings
+                 or held in tables. For each ATX requirement or table calls:
+- parseMarkdownFragment: Depending on the type of requirement calls one of the following functions.
+- parseReq: Parses ATX heading requirements into the Req structure and returns it.
+- parseReqTable: Parses a requirements table and reads each row into a Req structure, returned in a slice.
+*/
 package main
 
 import (
@@ -15,16 +26,36 @@ import (
 )
 
 var (
+	// The valid certification document filename format
+	reCertdoc = regexp.MustCompile(`^(\w+)-(\d+)-(\w+)$`)
+
 	// For detecting ATX Headings, see http://spec.commonmark.org/0.27/#atx-headings
 	reATXHeading = regexp.MustCompile(`(?m)^ {0,3}(#{1,6})( +(.*)( #* *)?)?$`)
+
+	// For detecting the first row and delimiter row of a requirement table
+	reTableHeader    = regexp.MustCompile(`(?m)^\| *ID *\|(?:[^\|]*\|)+$`)
+	reTableDelimiter = regexp.MustCompile(`(?m)^\|(?: *-+ *\|)+$`)
+
 	// REQ, project number, project abbreviation, req type, req number
 	// For example: REQ-TRAQ-SWH-4
-	reReqIdStr                 = `REQ-(\w+)-(\w+)-(\d+)`
-	ReReqID                    = regexp.MustCompile(reReqIdStr)
-	reReqIDBad                 = regexp.MustCompile(`(?i)REQ-((\d+)|((\w+)-(\d+)))`)
-	ReReqDeleted               = regexp.MustCompile(reReqIdStr + ` DELETED`)
+	reReqIdStr   = `REQ-(\w+)-(\w+)-(\d+)`
+	ReReqID      = regexp.MustCompile(reReqIdStr)
+	reReqIDBad   = regexp.MustCompile(`(?i)REQ-((\d+)|((\w+)-(\d+)))`)
+	ReReqDeleted = regexp.MustCompile(reReqIdStr + ` DELETED`)
+
+	// For detecting attributes sections and attributes
 	reAttributesSectionHeading = regexp.MustCompile(`(?m)\n#{2,6} Attributes:$`)
 	reReqKWD                   = regexp.MustCompile(`(?i)- ([^:]+): `)
+)
+
+// ReqType defines what type of requirement we are parsing. None, a heading based requirement or a table of
+// requirements.
+type ReqType int
+
+const (
+	None ReqType = iota
+	Heading
+	Table
 )
 
 // ParseCertdoc checks the f filename is a valid certdoc name then parses raw requirements out of it.
@@ -60,19 +91,19 @@ func ParseCertdoc(filename string) ([]*Req, error) {
 	return parseMarkdown(filename)
 }
 
-// parseMarkdown parses a certification document and returns the found
-// requirements.
-// @llr REQ-TRAQ-SWL-21
+// parseMarkdown parses a certification document and returns the found requirements.
+// @llr REQ-TRAQ-SWL-21, REQ-TRAQ-SWL-24
 func parseMarkdown(f string) ([]*Req, error) {
 	var (
 		reqs []*Req
 
 		lastHeadingLevel int // The level of the last ATX heading.
 		lastHeadingLine  int // The line number of the last ATX heading.
-		inReq            bool
 		reqLevel         int // The level of the ATX heading starting the requirement.
 		reqLine          int // The line number of the ATX heading starting the requirement.
-		reqBuf           bytes.Buffer
+
+		reqBuf bytes.Buffer // Temporary buffer for the fragment being read in.
+		inReq  ReqType      // The type of fragment being read.
 	)
 
 	r, err := os.Open(f)
@@ -81,24 +112,24 @@ func parseMarkdown(f string) ([]*Req, error) {
 	}
 	scan := bufio.NewScanner(r)
 
+	// scan through the markdown, one line at a time
 	for lno := 1; scan.Scan(); lno++ {
 		line := scan.Text()
 
-		var level int
-		parts := reATXHeading.FindStringSubmatch(line)
-		if parts != nil {
-			// An ATX heading.
-			level = len(parts[1])
-			title := parts[3]
+		// check if we've hit an ATX heading or the first row of a requirements table
+		if reATXHeading.MatchString(line) {
+			// it's an ATX heading
+			ATXparts := reATXHeading.FindStringSubmatch(line)
+			level := len(ATXparts[1])
+			title := ATXparts[3]
 			reqIDs := ReReqID.FindAllString(title, -1)
 			if len(reqIDs) > 1 {
 				return nil, fmt.Errorf("malformed requirement title: too many IDs on line %d: %q", lno, line)
 			}
 			headingHasReqID := len(reqIDs) == 1
-			// Figure out what to do with this heading.
-			end := false
-			start := false
-			if inReq {
+
+			// Check this heading is at the correct level given it's position in the document
+			if inReq == Heading {
 				// A request is currently being parsed.
 				if headingHasReqID {
 					// This is a requirement heading.
@@ -106,9 +137,6 @@ func parseMarkdown(f string) ([]*Req, error) {
 					if level != reqLevel {
 						return nil, fmt.Errorf("requirement heading on line %d must be at same level as requirement heading on line %d (%d != %d): %q", lno, reqLine, level, reqLevel, line)
 					}
-					// Besides starting a requirement, this heading also ends the current one.
-					end = true
-					start = true
 				} else {
 					// No requirement ID on this heading.
 					// The heading level must be lower or higher than the current
@@ -116,12 +144,6 @@ func parseMarkdown(f string) ([]*Req, error) {
 					// with other headings of the same level, in the same section.
 					if level == reqLevel {
 						return nil, fmt.Errorf("non-requirement heading on line %d at same level as requirement heading on line %d (%d): %q", lno, reqLine, level, line)
-					}
-					if level < reqLevel {
-						// Higher-level heading.
-						end = true
-					} else {
-						// Lower-level heading. Will be included in the current requirement.
 					}
 				}
 			} else {
@@ -131,50 +153,73 @@ func parseMarkdown(f string) ([]*Req, error) {
 					if level == lastHeadingLevel {
 						return nil, fmt.Errorf("requirement heading on line %d at same level as previous heading on line %d (%d): %q", lno, lastHeadingLine, level, line)
 					}
-					start = true
-				} else {
-					// No requirement ID on this heading. Will be ignored.
 				}
 			}
 
-			if end {
-				// Close the current requirement.
-				newReq, err := parseReq(reqBuf.String())
-				if err != nil {
-					return nil, err
-				}
-				reqs = append(reqs, newReq)
-				inReq = false
+			// If we're currently parsing a requirement and it's appropriate close it
+			if (inReq != None) && (headingHasReqID || level < reqLevel) {
+				reqs, err = parseMarkdownFragment(inReq, reqBuf.String(), reqs)
+				inReq = None
 			}
-			if start {
-				// Start a new requirement at the current line.
-				inReq = true
+
+			// If this is the start of a new requirement initialise data
+			if headingHasReqID {
+				inReq = Heading
 				reqLevel = level
 				reqLine = lno
 				reqBuf.Reset()
 				line = title
 			}
+			if level > 0 {
+				lastHeadingLevel = level
+				lastHeadingLine = lno
+			}
+		} else if reTableHeader.MatchString(line) {
+			// It's a requirements table
+			// If we're currently parsing a requirement close it
+			if inReq != None {
+				reqs, err = parseMarkdownFragment(inReq, reqBuf.String(), reqs)
+			}
+			// Start a new requirement table
+			inReq = Table
+			reqBuf.Reset()
 		}
-		if inReq {
+
+		if inReq != None {
 			reqBuf.WriteString(line)
 			reqBuf.WriteString("\n")
-		}
-		if level > 0 {
-			lastHeadingLevel = level
-			lastHeadingLine = lno
 		}
 	}
 	if err := scan.Err(); err != nil {
 		return nil, err
 	}
 
-	if inReq {
+	if inReq != None {
 		// Close the current requirement, we're at the end.
-		newReq, err := parseReq(reqBuf.String())
+		reqs, err = parseMarkdownFragment(inReq, reqBuf.String(), reqs)
+	}
+
+	return reqs, nil
+}
+
+// parseMarkdownFragment accepts a string containing either an ATX requirement or a requirements table and calls the
+// appropriate parsing function
+func parseMarkdownFragment(reqType ReqType, txt string, reqs []*Req) ([]*Req, error) {
+
+	if reqType == Heading {
+		// An ATX requirement
+		newReq, err := parseReq(txt)
 		if err != nil {
-			return nil, err
+			return reqs, err
 		}
 		reqs = append(reqs, newReq)
+	} else {
+		var err error
+		// A requirements table
+		reqs, err = parseReqTable(txt, reqs)
+		if err != nil {
+			return reqs, err
+		}
 	}
 
 	return reqs, nil
@@ -201,29 +246,14 @@ func parseMarkdown(f string) ([]*Req, error) {
 //
 // @llr REQ-TRAQ-SWL-13
 func parseReq(txt string) (*Req, error) {
-	head := txt
-	if len(head) > 40 {
-		head = head[:40]
-	}
-	defid := ReReqID.FindStringSubmatchIndex(txt)
-	if len(defid) == 0 {
-		if reReqIDBad.MatchString(head) {
-			return nil, fmt.Errorf("malformed requirement: found only malformed ID: %q (doesn't match %q)", head, ReReqID)
-		}
-		return nil, fmt.Errorf("malformed requirement: missing ID in first 40 characters: %q", head)
-	}
 
-	if defid[0] > 0 {
-		return nil, fmt.Errorf("malformed requirement: ID must be at the start of the title: %q", head)
-	}
-
-	IDNumber, err := strconv.Atoi(txt[defid[6]:defid[7]])
+	ID, IDNumber, err := extractIDAndNum(txt)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &Req{
-		ID:         txt[defid[0]:defid[1]],
+		ID:         ID,
 		IDNumber:   IDNumber,
 		Attributes: map[string]string{},
 	}
@@ -234,7 +264,8 @@ func parseReq(txt string) (*Req, error) {
 	}
 
 	// chop defining ID and any punctuation
-	txt = strings.TrimLeftFunc(txt[defid[1]:], IsPunctOrSpace)
+	txt = strings.TrimPrefix(txt, ID)
+	txt = strings.TrimLeftFunc(txt, IsPunctOrSpace)
 
 	// The first line is the title.
 	parts := strings.SplitN(strings.TrimSpace(txt), "\n", 2)
@@ -284,20 +315,163 @@ func parseReq(txt string) (*Req, error) {
 	}
 
 	// PARENTS must be punctuation/space separated list of parseable req-ids.
-	parents := r.Attributes["PARENTS"]
-	parmatch := ReReqID.FindAllStringSubmatchIndex(parents, -1)
-	for i, ids := range parmatch {
-		val := parents[ids[0]:ids[1]]
-		r.ParentIds = append(r.ParentIds, val)
-		if i > 0 {
-			sep := parents[parmatch[i-1][1]:ids[0]]
-			if strings.TrimFunc(sep, IsPunctOrSpace) != "" {
-				return nil, fmt.Errorf("requirement %s parents: unparseable as list of requirement ids: %q in %q", r.ID, sep, parents)
-			}
-		}
+	err = parseParents(r)
+	if err != nil {
+		return nil, err
 	}
 
 	return r, nil
+}
+
+// parseReqTable reads a table of requirements one row at a time and parses the content into Req structures which are
+// then returned in a slice.
+//
+// Tables have the following format:
+// | ID | Title | Body | Attribute1 | Attribute2 |
+// | --- | --- | --- | --- | --- |
+// | ReqID | <text> | <text> | <text> | <text> |
+//
+// The first column must be "ID" and each row must contain a valid ReqID. Other columns are optional.
+//
+// @llr REQ-TRAQ-SWL-25
+func parseReqTable(txt string, reqs []*Req) ([]*Req, error) {
+
+	var attributes []string
+
+	// Split the table into rows and loop through
+	for rowN, rowS := range strings.Split(txt, "\n") {
+
+		// The first row contains the attribute names for each column, the first column must be "ID"
+		if rowN == 0 {
+			if reTableHeader.MatchString(rowS) {
+				attributes = splitTableLine(rowS)
+				for i, a := range attributes {
+					attributes[i] = strings.ToUpper(a)
+				}
+			} else {
+				return reqs, fmt.Errorf("first column must be \"ID\"")
+			}
+		} else {
+			if reTableDelimiter.MatchString(rowS) {
+				// Ignore the delimiter row
+				continue
+			}
+
+			values := splitTableLine(rowS)
+
+			if len(values) == 0 {
+				// End of table
+				break
+			}
+
+			if len(values) < len(attributes) {
+				return reqs, fmt.Errorf("too few cells on row %d of requirement table", rowN+1)
+			}
+
+			r := &Req{Attributes: map[string]string{}}
+
+			// For each attribute in the first row, read in the associated value on this row
+			for i, k := range attributes {
+				if k == "ID" {
+					ID, IDNumber, err := extractIDAndNum(values[i])
+					if err != nil {
+						return reqs, err
+					}
+					r.ID = ID
+					r.IDNumber = IDNumber
+				} else if k == "TITLE" {
+					r.Title = values[i]
+				} else if k == "BODY" {
+					r.Body = values[i]
+				} else {
+					if k == "PARENT" {
+						// make our lives easier, accept both, output only PARENTS
+						k = "PARENTS"
+					}
+
+					if values[i] != "" {
+						r.Attributes[k] = values[i]
+					}
+				}
+			}
+
+			err := parseParents(r)
+			if err != nil {
+				return reqs, err
+			}
+
+			reqs = append(reqs, r)
+		}
+	}
+
+	return reqs, nil
+}
+
+// splitTableLine splits a pipe table row in cells. Does not count for
+// escaped `|` characters or other cases when `|` should not be considered
+// a cell separator. Removes the first and last parts if they are empty.
+func splitTableLine(line string) []string {
+	// The `|` at the beginning of the line is ignored because it
+	// represents visually the table's left side.
+	parts := strings.Split(line, "|")
+	if parts[0] == "" {
+		parts = parts[1:]
+	}
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	// Trim the space from each cell.
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+	return parts
+}
+
+// extractIDAndNum parses a requirement identifier string and returns the ID string and sequence number
+func extractIDAndNum(reqStr string) (string, int, error) {
+	head := reqStr
+	if len(head) > 40 {
+		head = head[:40]
+	}
+	defid := ReReqID.FindStringSubmatchIndex(reqStr)
+	if len(defid) == 0 {
+		if reReqIDBad.MatchString(reqStr) {
+			return "", 0, fmt.Errorf("malformed requirement: found only malformed ID: %q (doesn't match %q)", head, ReReqID)
+		}
+		return "", 0, fmt.Errorf("malformed requirement: missing ID in first 40 characters: %q", head)
+	}
+
+	if defid[0] > 0 {
+		return "", 0, fmt.Errorf("malformed requirement: ID must be at the start of the title: %q", head)
+	}
+
+	IDNumber, err := strconv.Atoi(reqStr[defid[6]:defid[7]])
+	if err != nil {
+		return "", 0, err
+	}
+	return reqStr[defid[0]:defid[1]], IDNumber, nil
+}
+
+// parseParents validates the Parents attribute of a requirement
+func parseParents(r *Req) error {
+	// PARENTS must be punctuation/space separated list of parseable req-ids.
+	parents := r.Attributes["PARENTS"]
+	parmatch := ReReqID.FindAllStringSubmatchIndex(parents, -1)
+
+	var parentIDs []string
+
+	for i, ids := range parmatch {
+		val := parents[ids[0]:ids[1]]
+		parentIDs = append(parentIDs, val)
+		if i > 0 {
+			sep := parents[parmatch[i-1][1]:ids[0]]
+			if strings.TrimFunc(sep, IsPunctOrSpace) != "" {
+				return fmt.Errorf("requirement %s parents: unparseable as list of requirement ids: %q in %q", r.ID, sep, parents)
+			}
+		}
+	}
+	r.ParentIds = parentIDs
+	return nil
 }
 
 func IsPunctOrSpace(r rune) bool {

--- a/req.go
+++ b/req.go
@@ -37,7 +37,6 @@ func (rs RequirementStatus) String() string { return reqStatusToString[rs] }
 
 var (
 	// project abbreviation, certdoc type number, certdoc type
-	reCertdoc = regexp.MustCompile(`^(\w+)-(\d+)-(\w+)$`)
 	reDiffRev = regexp.MustCompile(`Differential Revision:\s(.*)\s`)
 )
 

--- a/req.go
+++ b/req.go
@@ -36,7 +36,6 @@ var reqStatusToString = map[RequirementStatus]string{
 func (rs RequirementStatus) String() string { return reqStatusToString[rs] }
 
 var (
-	// project abbreviation, certdoc type number, certdoc type
 	reDiffRev = regexp.MustCompile(`Differential Revision:\s(.*)\s`)
 )
 
@@ -436,6 +435,12 @@ func (a byPosition) Len() int           { return len(a) }
 func (a byPosition) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byPosition) Less(i, j int) bool { return a[i].Position < a[j].Position }
 
+type byIDNumber []*Req
+
+func (a byIDNumber) Len() int           { return len(a) }
+func (a byIDNumber) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byIDNumber) Less(i, j int) bool { return a[i].IDNumber < a[j].IDNumber }
+
 type byFilenameTag []*Code
 
 func (a byFilenameTag) Len() int      { return len(a) }
@@ -456,10 +461,16 @@ func parseCertdocToGraph(fileName string, graph *reqGraph) ([]error, error) {
 		return nil, fmt.Errorf("error parsing %s: %v", fileName, err)
 	}
 
-	isReqPresent := make([]bool, len(reqs))
+	// sort the requirements so we can check the sequence
+	sort.Sort(byIDNumber(reqs))
+
+	isReqPresent := make([]bool, reqs[len(reqs)-1].IDNumber)
+	NextId := 1
+
 	var errs []error
 	for i, r := range reqs {
-		errs2 := lintReq(fileName, len(reqs), isReqPresent, r)
+		errs2 := lintReq(fileName, NextId, isReqPresent, r)
+		NextId = r.IDNumber + 1
 		if len(errs2) != 0 {
 			errs = append(errs, errs2...)
 			continue
@@ -473,7 +484,7 @@ func parseCertdocToGraph(fileName string, graph *reqGraph) ([]error, error) {
 // lintReq is called for each requirement while building the req graph
 // @llr REQ-TRAQ-SWL-3
 // @llr REQ-TRAQ-SWL-5
-func lintReq(fileName string, nReqs int, isReqPresent []bool, r *Req) []error {
+func lintReq(fileName string, expectedIDNumber int, isReqPresent []bool, r *Req) []error {
 	// extract file name without extension
 	fNameWithExt := path.Base(fileName)
 	extension := filepath.Ext(fNameWithExt)
@@ -504,18 +515,17 @@ func lintReq(fileName string, nReqs int, isReqPresent []bool, r *Req) []error {
 	if err2 != nil {
 		errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s (failed to parse): %s", r.ID, reqIDComps[3]))
 	} else {
-		// check requirement sequence number
-		if currentID > nReqs {
-			errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s: missing requirements in between. Total number of requirements is %d.", r.ID, nReqs))
+		if currentID < 1 {
+			errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s: first requirement has to start with 001.", r.ID))
 		} else {
-			if currentID < 1 {
-				errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s: first requirement has to start with 001.", r.ID))
+			if isReqPresent[currentID-1] {
+				errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s, is duplicate.", r.ID))
 			} else {
-				if isReqPresent[currentID-1] {
-					errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s, is duplicate.", r.ID))
+				if currentID != expectedIDNumber {
+					errs = append(errs, fmt.Errorf("Invalid requirement sequence number for %s: missing requirements in between. Expected ID Number %d.", r.ID, expectedIDNumber))
 				}
-				isReqPresent[currentID-1] = true
 			}
+			isReqPresent[currentID-1] = true
 		}
 	}
 

--- a/req_test.go
+++ b/req_test.go
@@ -208,6 +208,7 @@ func TestReq_Matches_filter(t *testing.T) {
 }
 
 func TestParsing(t *testing.T) {
+	// test a valid requirements document
 	f := "testdata/valid_system_requirement/TEST-100-ORD.md"
 	rg := &reqGraph{Reqs: make(map[string]*Req)}
 
@@ -238,6 +239,44 @@ func TestParsing(t *testing.T) {
 			t.Errorf("Invalid system requirement\nExpected %#v,\n   got %#v", systemReqs[i], systemReq)
 		}
 	}
+
+	// an invalid requirements document containing requirement naming errors
+	f = "testdata/invalid_system_requirement/NAM1-100-ORD.md"
+	rg = &reqGraph{Reqs: make(map[string]*Req)}
+
+	errors, err = parseCertdocToGraph(f, rg)
+	if err != nil {
+		t.Errorf("parseCertdocToGraph: %v", err)
+	}
+	assert.Equal(t, 3, len(errors))
+	assert.Contains(t, errors[0].Error(), "Incorrect project abbreviation for requirement REQ-NAN1-SYS-1. Expected NAM1, got NAN1.")
+	assert.Contains(t, errors[1].Error(), "Incorrect requirement type for requirement REQ-NAM1-SWH-2. Expected SYS, got SWH.")
+	assert.Contains(t, errors[2].Error(), "Requirement number cannot begin with a 0: REQ-NAM1-SYS-03. Got 03.")
+
+	// an invalid requirements document containing sequence errors
+	f = "testdata/invalid_system_requirement/GAP1-100-ORD.md"
+	rg = &reqGraph{Reqs: make(map[string]*Req)}
+
+	errors, err = parseCertdocToGraph(f, rg)
+	if err != nil {
+		t.Errorf("parseCertdocToGraph: %v", err)
+	}
+	assert.Equal(t, 2, len(errors))
+	assert.Contains(t, errors[0].Error(), "Invalid requirement sequence number for REQ-GAP1-SYS-3: missing requirements in between. Expected ID Number 2.")
+	assert.Contains(t, errors[1].Error(), "Invalid requirement sequence number for REQ-GAP1-SYS-6: missing requirements in between. Expected ID Number 5.")
+
+	// an invalid requirements document containing duplicates
+	f = "testdata/invalid_system_requirement/DUP1-100-ORD.md"
+	rg = &reqGraph{Reqs: make(map[string]*Req)}
+
+	errors, err = parseCertdocToGraph(f, rg)
+	if err != nil {
+		t.Errorf("parseCertdocToGraph: %v", err)
+	}
+	assert.Equal(t, 3, len(errors))
+	assert.Contains(t, errors[0].Error(), "Invalid requirement sequence number for REQ-DUP1-SYS-1, is duplicate.")
+	assert.Contains(t, errors[1].Error(), "Invalid requirement sequence number for REQ-DUP1-SYS-2, is duplicate.")
+	assert.Contains(t, errors[2].Error(), "Invalid requirement sequence number for REQ-DUP1-SYS-3, is duplicate.")
 }
 
 func TestReq_IsDeleted(t *testing.T) {

--- a/req_test.go
+++ b/req_test.go
@@ -210,10 +210,15 @@ func TestReq_Matches_filter(t *testing.T) {
 func TestParsing(t *testing.T) {
 	f := "testdata/valid_system_requirement/TEST-100-ORD.md"
 	rg := &reqGraph{Reqs: make(map[string]*Req)}
-	errors, _ := parseCertdocToGraph(f, rg)
+
+	errors, err := parseCertdocToGraph(f, rg)
+	if err != nil {
+		t.Errorf("parseCertdocToGraph: %v", err)
+	}
 	assert.Empty(t, errors, "Unexpected errors while parsing "+f)
-	var systemReqs [5]Req
-	for i := 0; i < 5; i++ {
+
+	var systemReqs [14]Req
+	for i := 0; i < 14; i++ {
 		reqNo := strconv.Itoa(i + 1)
 		systemReqs[i] = Req{ID: "REQ-TEST-SYS-" + reqNo,
 			Level:    config.SYSTEM,
@@ -225,6 +230,8 @@ func TestParsing(t *testing.T) {
 				"VERIFICATION":  "Test " + reqNo},
 		}
 	}
+
+	assert.Equal(t, len(systemReqs), len(rg.Reqs), "Requirement count mismatch")
 
 	for i, systemReq := range rg.OrdsByPosition() {
 		if systemReqs[i].ID != systemReq.ID || systemReqs[i].Level != systemReq.Level || systemReqs[i].Path != systemReq.Path || systemReqs[i].Position != systemReq.Position {

--- a/testdata/invalid_system_requirement/DUP1-100-ORD.md
+++ b/testdata/invalid_system_requirement/DUP1-100-ORD.md
@@ -1,0 +1,40 @@
+# ReqTraq Test File
+
+This file is used as a test input for the reqtraq tool. Invalid due to duplicates in the requirement number sequence.
+
+## List Of Requirements
+
+### REQ-DUP1-SYS-1 Section 1
+
+Body of requirement 1.
+
+###### Attributes:
+- Rationale: Rationale 1
+- Verification: Test 1
+- Safety impact: Impact 1
+
+### REQ-DUP1-SYS-1 Section 1
+
+Body of requirement 1.
+
+###### Attributes:
+- Rationale: Rationale 1
+- Verification: Test 1
+- Safety impact: Impact 1
+
+### REQ-DUP1-SYS-2 Section 2
+
+Body of requirement 2.
+
+###### Attributes:
+- Rationale: Rationale 2
+- Verification: Test 2
+- Safety impact: Impact 2
+
+## Table Of Requirements
+
+| ID | Title | Body | Rationale | Verification | Safety impact |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| REQ-DUP1-SYS-2 | Section 2 | Body of requirement 2. | Rationale 2 | Test 2 | Impact 2 |
+| REQ-DUP1-SYS-3 | Section 3 | Body of requirement 3. | Rationale 3 | Test 3 | Impact 3 |
+| REQ-DUP1-SYS-3 | Section 3 | Body of requirement 3. | Rationale 3 | Test 3 | Impact 3 |

--- a/testdata/invalid_system_requirement/GAP1-100-ORD.md
+++ b/testdata/invalid_system_requirement/GAP1-100-ORD.md
@@ -1,0 +1,31 @@
+# ReqTraq Test File
+
+This file is used as a test input for the reqtraq tool. Invalid due to gaps in the requirement number sequence.
+
+## List Of Requirements
+
+### REQ-GAP1-SYS-1 Section 1
+
+Body of requirement 1.
+
+###### Attributes:
+- Rationale: Rationale 1
+- Verification: Test 1
+- Safety impact: Impact 1
+
+### REQ-GAP1-SYS-3 Section 3
+
+Body of requirement 3.
+
+###### Attributes:
+- Rationale: Rationale 3
+- Verification: Test 3
+- Safety impact: Impact 3
+
+## Table Of Requirements
+
+| ID | Title | Body | Rationale | Verification | Safety impact |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| REQ-GAP1-SYS-4 | Section 4 | Body of requirement 4. | Rationale 4 | Test 4 | Impact 4 |
+| REQ-GAP1-SYS-6 | Section 6 | Body of requirement 6. | Rationale 6 | Test 6 | Impact 6 |
+

--- a/testdata/invalid_system_requirement/NAM1-100-ORD.md
+++ b/testdata/invalid_system_requirement/NAM1-100-ORD.md
@@ -1,0 +1,32 @@
+# ReqTraq Test File
+
+This file is used as a test input for the reqtraq tool. Invalid due to errors in the format of the requirement numbers.
+
+## List Of Requirements
+
+### REQ-NAN1-SYS-1 Section 1
+
+Body of requirement 1.
+
+###### Attributes:
+- Rationale: Rationale 1
+- Verification: Test 1
+- Safety impact: Impact 1
+
+### REQ-NAM1-SWH-2 Section 2
+
+Body of requirement 2.
+
+###### Attributes:
+- Rationale: Rationale 2
+- Verification: Test 2
+- Safety impact: Impact 2
+
+### REQ-NAM1-SYS-03 Section 3
+
+Body of requirement 3.
+
+###### Attributes:
+- Rationale: Rationale 3
+- Verification: Test 3
+- Safety impact: Impact 3

--- a/testdata/valid_system_requirement/TEST-100-ORD.md
+++ b/testdata/valid_system_requirement/TEST-100-ORD.md
@@ -49,3 +49,44 @@ Body of requirement 5.
 - Rationale: Rationale 5
 - Verification: Test 5
 - Safety impact: Impact 5
+
+
+## Table Of Requirements
+
+| ID | Title | Body | Rationale | Verification | Safety impact |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| REQ-TEST-SYS-6 | Section 4 | Body of requirement 6. | Rationale 6 | Test 6 | Impact 6 |
+| REQ-TEST-SYS-7 | DELETED | Body of requirement 7. | Rationale 7 | Test 7 | Impact 7 |
+| REQ-TEST-SYS-8 | Section 5 | Body of requirement 8. | Rationale 8 | Test 8 | Impact 8 |
+| REQ-TEST-SYS-9 | Section 6 | Body of requirement 9. | Rationale 9 | Test 9 | Impact 9 |
+
+
+## Another List Of Requirements
+
+### REQ-TEST-SYS-10 Section 7
+
+Body of requirement 10.
+
+###### Attributes:
+- Rationale: Rationale 10
+- Verification: Test 10
+- Safety impact: Impact 10
+
+### REQ-TEST-SYS-11 Section 8
+
+Body of requirement 11.
+
+###### Attributes:
+- Rationale: Rationale 11
+- Verification: Test 11
+- Safety impact: Impact 11
+
+
+## Another Table Of Requirements
+
+| ID | Title | Body | Rationale | Verification | Safety impact |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+| REQ-TEST-SYS-12 | Section 9 | Body of requirement 12. | Rationale 12 | Test 12 | Impact 12 |
+| REQ-TEST-SYS-13 | Section 10 | Body of requirement 13. | Rationale 13 | Test 13 | Impact 13 |
+| REQ-TEST-SYS-14 | Section 11 | Body of requirement 14. | Rationale 14 | Test 14 | Impact 14 |
+


### PR DESCRIPTION
…on to ATX headings

The main changes in this pull request are in parsing.go. Previously the parseMarkdown function scanned for requirements bound by ATX headings and called parseReq for each one encountered. parseMarkdown has been updated to scan for both ATX headings and markdown tables, when the end of a ATX-type requirement or requirement table is encountered a new function parseMarkdownFragment is called which either calls parseReq for ATX-type or parseReqTable for tables. A couple of the actions performed by parseReq are also needed for requirement tables, namely parsing requirement IDs and the PARENTS attribute, so these have been broken out into utility functions extractIDAndNum and parseParents. Other changes in parsing.go are fairly self explanatory.

In addition unit tests in parsing_test.go and req_test.go have been updated to exercise the table parsing. Plus the low-level requirements have been updated to cover the new functionality.