### PR TITLE
Improved parsing of requirements IDs in source code; Moved parsing co…

### DIFF
--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -72,7 +72,7 @@ ReqGraph source code is arranged as follows:
 
 ### code.go
 
-Functions which deal with source code files. Source code is discovered within a given path and searched for functions and associated descriptions. The external program Universal Ctags is used to scan for functions.
+Functions which deal with source code files. Source code is discovered within a given path and searched for functions and associated requirement IDs. The external program Universal Ctags is used to scan for functions.
 
 #### REQ-TRAQ-SWL-6 Scan for source code
 
@@ -104,9 +104,9 @@ Reqtraq SHALL use the Universal Ctags application to parse supported source code
 - Verification: Test
 - Safety Impact: None
 
-#### REQ-TRAQ-SWL-9 Comments
+#### REQ-TRAQ-SWL-9 Requirement IDs
 
-Reqtraq SHALL scan source code containing functions for comments preceding the functions, and store them.
+Reqtraq SHALL scan source code containing functions for comments which contain requirement IDs preceding the functions, and store them.
 
 ##### Attributes:
 - Parents: REQ-TRAQ-SWH-2

--- a/code.go
+++ b/code.go
@@ -1,23 +1,32 @@
 /*
-Functions which deal with source code files. Source code is discovered within a given path and searched for functions and associated descriptions. The external program Universal Ctags is used to scan for functions.
+Functions which deal with source code files. Source code is discovered within a given path and searched for functions and associated requirement IDs. The external program Universal Ctags is used to scan for functions.
 */
 
 package main
 
 import (
-	"bufio"
-	"crypto/sha1"
 	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/daedaleanai/reqtraq/git"
 	"github.com/daedaleanai/reqtraq/linepipes"
 	"github.com/pkg/errors"
+)
+
+var (
+	// To detect a line containing low-level requirements
+	reLLRReferenceLine = regexp.MustCompile(`^[ \*\/]*(?:@|\\)llr (?:REQ-\w+-\w+-\d+[, ]*)+$`)
+	// To capture requirements out of the line
+	reLLRReferences = regexp.MustCompile(`(REQ-\w+-\w+-\d+)`)
+	// Blank line to stop search
+	reBlankLine = regexp.MustCompile(`^\s*$`)
 )
 
 // Code represents a code node in the graph of requirements.
@@ -28,15 +37,12 @@ type Code struct {
 	Tag string
 	// Line number where the function starts.
 	Line int
-	// The comment above the function.
-	Comment []string
-	// FileHash is the sha1 of the contents.
-	FileHash  string
+	// Requirement IDs found in the comment above the function.
 	ParentIds []string
 	Parents   []*Req
 }
 
-// ParseCode is the entry point for the code related functions. Given a path containing source code the code files are found, the procedures within them, along with their comment descriptions, discovered. The return value is a map from each discovered source code file to a slice of Code structs representing the functions found within.
+// ParseCode is the entry point for the code related functions. Given a path containing source code the code files are found, the procedures within them, along with their associated requirement IDs, discovered. The return value is a map from each discovered source code file to a slice of Code structs representing the functions found within.
 // @llr REQ-TRAQ-SWL-6 REQ-TRAQ-SWL-8 REQ-TRAQ-SWL-9
 func ParseCode(codePath string) (map[string][]*Code, error) {
 
@@ -56,7 +62,7 @@ func ParseCode(codePath string) (map[string][]*Code, error) {
 		return codeTags, errors.Wrap(err, "failed to tag code")
 	}
 
-	// Annotate the code procedures with the associated comment.
+	// Annotate the code procedures with the associated requirement IDs.
 	if err := parseComments(codeFiles, codeTags); err != nil {
 		return codeTags, errors.Wrap(err, "failed walking code")
 	}
@@ -64,10 +70,10 @@ func ParseCode(codePath string) (map[string][]*Code, error) {
 	return codeTags, nil
 }
 
-// URL create a URL path to a code function by concatinating the source code path and line number of the function comment.
+// URL create a URL path to a code function by concatenating the source code path and line number of the function
 // @llr REQ-TRAQ-SWL-38
 func (code *Code) URL() string {
-	return fmt.Sprintf("/code/%s#L%d", code.Path, code.Line-len(code.Comment))
+	return fmt.Sprintf("/code/%s#L%d", code.Path, code.Line)
 }
 
 // SourceCodeFileExtensions are listed by language.
@@ -149,7 +155,7 @@ func isSourceCodeFile(name string) bool {
 	return false
 }
 
-// parseComments updates the specified tags with the comments discovered in the CodeFiles.
+// parseComments updates the specified tags with the requirement IDs discovered in the codeFiles.
 // @llr REQ-TRAQ-SWL-9
 func parseComments(codeFiles []string, codeTags map[string][]*Code) error {
 	repoPath := git.RepoPath()
@@ -162,50 +168,40 @@ func parseComments(codeFiles []string, codeTags map[string][]*Code) error {
 	return nil
 }
 
-// parseFileComments detects comments in the specified source code file and associates them with the tags detected in the same file.
+// parseFileComments detects comments in the specified source code file, parses them for requirements IDs and
+// associates them with the tags detected in the same file.
 // @llr REQ-TRAQ-SWL-9
 func parseFileComments(absolutePath string, tags []*Code) error {
-	f, err := os.Open(absolutePath)
+	// Read in the source code and break into string slice
+	sourceRaw, err := os.ReadFile(absolutePath)
 	if err != nil {
 		return err
 	}
-	h := sha1.New()
-	// git compatible hash
-	if s, err := f.Stat(); err == nil {
-		fmt.Fprintf(h, "blob %d", s.Size())
-		h.Write([]byte{0})
-	}
+	sourceLines := strings.Split(string(sourceRaw), "\n")
 
-	// Detect comments.
-	comments := make(map[int][]string, 0)
-	scanner := bufio.NewScanner(io.TeeReader(f, h))
-	var comment []string
-	var lineNumber int
-	for scanner.Scan() {
-		lineNumber++
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "//") || strings.HasPrefix(line, "*/") || strings.HasPrefix(line, "/*") || strings.HasPrefix(line, "* ") {
-			if comment == nil {
-				comment = make([]string, 0)
-			}
-			comment = append(comment, line)
-		} else {
-			if comment != nil {
-				// This is the first line after the comment.
-				comments[lineNumber] = comment
-				comment = nil
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return errors.Wrap(err, "failed to read source code file")
-	}
+	// Sort the tags so they're in line number order
+	sort.Sort(byFilenameTag(tags))
 
-	// Associate the detected comments with the tags.
+	// For each tag, search through the source code backwards looking for requirement references
+	previousTag := 0
 	for i := range tags {
-		if comment, ok := comments[tags[i].Line]; ok {
-			tags[i].Comment = comment
+		if tags[i].Line == previousTag {
+			// If there's a duplicate tag then just copy the links and continue
+			tags[i].ParentIds = tags[i-1].ParentIds
+			continue
 		}
+		for lineNo := tags[i].Line - 1; lineNo > previousTag; lineNo-- {
+			if reLLRReferenceLine.MatchString(sourceLines[lineNo]) {
+				// Looks good, extract all references straight into the tag
+				tags[i].ParentIds = reLLRReferences.FindAllString(sourceLines[lineNo], -1)
+				break
+			} else if reBlankLine.MatchString(sourceLines[lineNo]) {
+				// We've hit a blank line
+				break
+			}
+
+		}
+		previousTag = tags[i].Line
 	}
 
 	return nil

--- a/code.go
+++ b/code.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	// To detect a line containing low-level requirements
-	reLLRReferenceLine = regexp.MustCompile(`^[ \*\/]*(?:@|\\)llr (?:REQ-\w+-\w+-\d+[, ]*)+$`)
+	reLLRReferenceLine = regexp.MustCompile(`^[ \*\/]*(?:@|\\)llr +(?:REQ-\w+-\w+-\d+[, ]*)+$`)
 	// To capture requirements out of the line
 	reLLRReferences = regexp.MustCompile(`(REQ-\w+-\w+-\d+)`)
 	// Blank line to stop search

--- a/code_test.go
+++ b/code_test.go
@@ -18,7 +18,7 @@ func TestCheckCtagsAvailable(t *testing.T) {
 type TagMatch struct {
 	tag       string
 	line      int
-	parentids string
+	parentIds string
 }
 
 func LookFor(t *testing.T, sourceFile string, tagsPerFile map[string][]*Code, expectedTags []TagMatch) {
@@ -33,8 +33,8 @@ func LookFor(t *testing.T, sourceFile string, tagsPerFile map[string][]*Code, ex
 				found = true
 				assert.Equal(t, e.line, tag.Line)
 				assert.Equal(t, e.tag, tag.Tag)
-				if e.parentids != "" {
-					assert.Equal(t, e.parentids, strings.Join(tag.ParentIds, ","))
+				if e.parentIds != "" {
+					assert.Equal(t, e.parentIds, strings.Join(tag.ParentIds, ","))
 				}
 				break
 			}

--- a/code_test.go
+++ b/code_test.go
@@ -16,9 +16,9 @@ func TestCheckCtagsAvailable(t *testing.T) {
 }
 
 type TagMatch struct {
-	tag     string
-	line    int
-	comment string
+	tag       string
+	line      int
+	parentids string
 }
 
 func LookFor(t *testing.T, sourceFile string, tagsPerFile map[string][]*Code, expectedTags []TagMatch) {
@@ -33,8 +33,8 @@ func LookFor(t *testing.T, sourceFile string, tagsPerFile map[string][]*Code, ex
 				found = true
 				assert.Equal(t, e.line, tag.Line)
 				assert.Equal(t, e.tag, tag.Tag)
-				if e.comment != "" {
-					assert.Equal(t, e.comment, strings.Join(tag.Comment, "\n"))
+				if e.parentids != "" {
+					assert.Equal(t, e.parentids, strings.Join(tag.ParentIds, ","))
 				}
 				break
 			}
@@ -84,16 +84,13 @@ func TestReqGraph_ParseCode(t *testing.T) {
 	expectedTags := []TagMatch{
 		{"enumerateObjects",
 			30,
-			`// This method does stuff also.
-// @llr REQ-TEST-SWL-13
-// @xlr R-1`},
+			`REQ-TEST-SWL-13`},
 		{"getSegment",
 			20,
-			`// This method does stuff.
-// @llr REQ-TEST-SWL-12`},
+			`REQ-TEST-SWL-12`},
 		{"getNumberOfSegments",
 			14,
-			`// @llr REQ-TEST-SWH-11`},
+			`REQ-TEST-SWH-11`},
 	}
 	LookFor(t, "testdata/cproject1/a.c", rg.CodeTags, expectedTags)
 
@@ -101,6 +98,6 @@ func TestReqGraph_ParseCode(t *testing.T) {
 	rg.Reqs["REQ-TEST-SWH-11"] = &Req{Level: config.HIGH}
 	errs := SortErrs(rg.resolve())
 	assert.Equal(t, 2, len(errs))
-	assert.Equal(t, "Invalid reference in file testdata/cproject1/a.c function getNumberOfSegments: REQ-TEST-SWH-11 must be a Low-Level Requirement.", errs[0])
-	assert.Equal(t, "Invalid reference in file testdata/cproject1/a.c function getSegment: REQ-TEST-SWL-12 does not exist.", errs[1])
+	assert.Equal(t, "Invalid reference in function getNumberOfSegments@testdata/cproject1/a.c:14, REQ-TEST-SWH-11 is not a low-level requirement.", errs[0])
+	assert.Equal(t, "Invalid reference in function getSegment@testdata/cproject1/a.c:20, REQ-TEST-SWL-12 does not exist.", errs[1])
 }


### PR DESCRIPTION
…de into code.go where it belongs.

Instead of parsing the comment text into the tag in code.go and then looking for requirement IDs later in req.go, just do it in one step and look for the requirement IDs from the beginning.