### PR TITLE
Add assumption-specific attributes

### DIFF
--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -803,6 +803,18 @@ A sample configuration file is shown below:
                 "prefix": "TEST",
                 "level": "SWH"
             },
+            "attributes": [
+                {
+                    "name": "Custom Attribute",
+                    "required": "false",
+                },
+            ],
+            "asmAttributes": [
+                {
+                    "name": "Validation",
+                    "required": "true",
+                },
+            ],
             "implementation": {
                 "code": {
                     "paths": ["code"],
@@ -832,6 +844,7 @@ specification of the parent so that requirements can be linked from children to 
 implies a `Parents` attribute with a filter for the requirement specification of the parent will be 
 added to the schema of the document.
 - An implementation, which consists of separated matchers for both code and tests.
+- Any attributes for its requirements and assumptions.
 
 Common attributes are appended to the attribute schema in each document to fully define the schema 
 of the attributes in the requirements that belong to the document.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -53,6 +53,12 @@ func TestConfig_ParseConfig(t *testing.T) {
 					"VERIFICATION":  commonAttributes["VERIFICATION"],
 					"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 				},
+				AsmAttributes: map[string]*Attribute{
+					"PARENTS": {
+						Value: regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+						Type:  AttributeRequired,
+					},
+				},
 			},
 			Implementation: Implementation{
 				CodeFiles: []string{},
@@ -78,6 +84,16 @@ func TestConfig_ParseConfig(t *testing.T) {
 					"PARENTS": {
 						Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
 						Type:  AttributeAny,
+					},
+				},
+				AsmAttributes: map[string]*Attribute{
+					"PARENTS": {
+						Value: regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+						Type:  AttributeRequired,
+					},
+					"VALIDATION": {
+						Value: regexp.MustCompile(".*"),
+						Type:  AttributeRequired,
 					},
 				},
 			},
@@ -107,6 +123,12 @@ func TestConfig_ParseConfig(t *testing.T) {
 		Attribute{
 			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
 			Type:  AttributeAny,
+		},
+	)
+	assert.Equal(t, *config.Repos["projectB"].Documents[0].Schema.AsmAttributes["PARENTS"],
+		Attribute{
+			Value: regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+			Type:  AttributeRequired,
 		},
 	)
 	assert.ElementsMatch(t, config.Repos["projectB"].Documents[0].Implementation.CodeFiles,

--- a/main_test.go
+++ b/main_test.go
@@ -252,7 +252,10 @@ func TestValidateMultipleRepos(t *testing.T) {
 	actual, err := RunValidate(t, &config)
 	assert.Empty(t, err, "Got unexpected error")
 
-	expected := `Validation passed`
+	expected := `Requirement 'ASM-TEST-SWH-3' is missing attribute 'VALIDATION'.
+Requirement 'ASM-TEST-SWH-3' has unknown attribute 'VERIFICATION'.
+Requirement 'ASM-TEST-SWH-2' has invalid value 'REQ-TEST-SYS-2' in attribute 'PARENTS'.
+WARNING. Validation failed`
 
 	checkValidateError(t, actual, expected)
 }

--- a/req.go
+++ b/req.go
@@ -172,14 +172,7 @@ func (rg *ReqGraph) resolve() []error {
 		}
 
 		// Validate attributes
-		var attributes map[string]*config.Attribute
-		switch req.Variant {
-		case ReqVariantRequirement:
-			attributes = req.Document.Schema.Attributes
-		case ReqVariantAssumption:
-			attributes = req.Document.Schema.AsmAttributes
-		}
-		errs = append(errs, req.checkAttributes(attributes)...)
+		errs = append(errs, req.checkAttributes()...)
 
 		// Validate parent links of requirements
 		for _, parentID := range req.ParentIds {
@@ -297,7 +290,15 @@ func (r *Req) IsDeleted() bool {
 // checkAttributes validates the requirement attributes against the schema from its document,
 // returns a list of errors found.
 // @llr REQ-TRAQ-SWL-10
-func (r *Req) checkAttributes(schemaAttributes map[string]*config.Attribute) []error {
+func (r *Req) checkAttributes() []error {
+	var schemaAttributes map[string]*config.Attribute
+	switch r.Variant {
+	case ReqVariantRequirement:
+		schemaAttributes = r.Document.Schema.Attributes
+	case ReqVariantAssumption:
+		schemaAttributes = r.Document.Schema.AsmAttributes
+	}
+
 	var errs []error
 	var anyAttributes []string
 	anyCount := 0

--- a/testdata/projectA/TEST-137-SRD.md
+++ b/testdata/projectA/TEST-137-SRD.md
@@ -23,3 +23,27 @@ Body of requirement 2.
 - Rationale: Rationale 2
 - Verification: Test 2
 - Safety impact: Impact 2
+
+### ASM-TEST-SWH-1 An assumption
+
+Assumptions have different attributes
+
+###### Attributes:
+- Parents: REQ-TEST-SWH-2
+- Validation: Some validation strategy
+
+### ASM-TEST-SWH-2 Another assumption
+
+This one should fail because of an invalid parent
+
+###### Attributes:
+- Parents: REQ-TEST-SYS-2
+- Validation: Some validation strategy
+
+### ASM-TEST-SWH-3 One more assumption
+
+This one should fail because of an invalid attribute
+
+###### Attributes:
+- Parents: REQ-TEST-SWH-2
+- Verification: Test 2

--- a/testdata/projectA/reqtraq_config.json
+++ b/testdata/projectA/reqtraq_config.json
@@ -32,7 +32,13 @@
             "parent": {
                 "prefix": "TEST",
                 "level": "SYS"
-            }
+            },
+            "asmAttributes": [
+                {
+                    "name": "Validation",
+                    "required": "true"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Assumptions cannot be validated with the same attributes as any other
requirements. In order to handle them, the configuration now includes an
asmAttributes field that will be part of the document schema and will be
used to validate assumptions.

Assumptions also have implicit parents attribute declaration, and must
be any requirements with the requirement specification of the document
in which they are defined