### PR TITLE
Allow code with optional requirement links

### DIFF
--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -143,6 +143,19 @@ but other parsers can optionally be compiled-in and registered during initializa
 - Verification: Test
 - Safety Impact: None
 
+#### REQ-TRAQ-SWL-69 Optional links to requirements
+
+Reqtraq SHALL provide functionality to optionally link code to requirements as determined by the
+code parser. If the code parser determines that the link is optional and no link is found, validation
+MUST pass. If the link is not optional and no link is found, validation MUST fail.
+
+##### Attributes:
+- Parents: 
+- Rationale: To allow adding requriements on type aliases without forcing all type aliases to have 
+linked requirements.
+- Verification: Test
+- Safety Impact: None
+
 ### diff.go
 
 Functions which compare two requirements graphs and return a map-of-slice-of-strings structure which describe how they differ.

--- a/clang_test.go
+++ b/clang_test.go
@@ -35,32 +35,33 @@ func TestTagCodeLibClang(t *testing.T) {
 	assert.Equal(t, 3, len(tags))
 
 	expectedTags := []TagMatch{
-		{"doThings", 17, ""},
-		{"doMoreThings", 23, ""},
-		{"Array<T, N>", 38, ""},
-		{"operator[]", 45, ""},
-		{"ButThisIsPublic", 59, ""},
-		{"StructMethodsArePublicByDefault", 66, ""},
-		{"JustAFreeFunction", 75, ""},
-		{"sort", 95, ""},
-		{"sort", 89, ""},
-		{"cool", 113, ""},
-		{"JustAFreeFunction", 119, ""},
+		{"doThings", 17, "", false},
+		{"doMoreThings", 23, "", false},
+		{"Array<T, N>", 38, "", false},
+		{"operator[]", 45, "", false},
+		{"ButThisIsPublic", 59, "", false},
+		{"StructMethodsArePublicByDefault", 66, "", false},
+		{"JustAFreeFunction", 75, "", false},
+		{"sort", 95, "", false},
+		{"sort", 89, "", false},
+		{"cool", 113, "", false},
+		{"JustAFreeFunction", 119, "", false},
 	}
 	LookFor(t, repoName, "code/include/a.hh", tags, expectedTags)
 
 	expectedTags = []TagMatch{
-		{"hiddenFunction", 9, ""},
-		{"doThings", 15, ""},
-		{"doMoreThings", 21, ""},
-		{"allReqsCovered", 24, ""},
+		{"hiddenFunction", 9, "", false},
+		{"doThings", 15, "", false},
+		{"doMoreThings", 21, "", false},
+		{"allReqsCovered", 24, "", false},
+		{"MyType", 27, "", true},
 	}
 	LookFor(t, repoName, "code/a.cc", tags, expectedTags)
 
 	expectedTags = []TagMatch{
-		{"TestDoThings", 9, ""},
-		{"TestDoMoreThings", 15, ""},
-		{"TestAllReqsCovered", 21, ""},
+		{"TestDoThings", 9, "", false},
+		{"TestDoMoreThings", 15, "", false},
+		{"TestAllReqsCovered", 21, "", false},
 	}
 	LookFor(t, repoName, "test/a/a_test.cc", tags, expectedTags)
 }

--- a/code.go
+++ b/code.go
@@ -83,12 +83,14 @@ type Code struct {
 	Parents   []*Req
 	// Link back to its parent document. Used to validate the requirements belong to this document
 	Document *config.Document
+	// Whether the code MUST link to a requirement or simply CAN link to a requirement
+	Optional bool
 }
 
 // ParseCode is the entry point for the code related functions. It parses all tags found in the
 // implementation for the given document. The return value is a map from each discovered source code
 // file to a slice of Code structs representing the functions found within.
-// @llr REQ-TRAQ-SWL-8 REQ-TRAQ-SWL-9, REQ-TRAQ-SWL-61
+// @llr REQ-TRAQ-SWL-8 REQ-TRAQ-SWL-9, REQ-TRAQ-SWL-61, REQ-TRAQ-SWL-69
 func ParseCode(repoName repos.RepoName, document *config.Document) (map[CodeFile][]*Code, error) {
 	// Create a list with all the files to parse
 	codeFiles := make([]CodeFile, 0)

--- a/code_test.go
+++ b/code_test.go
@@ -33,6 +33,7 @@ type TagMatch struct {
 	tag       string
 	line      int
 	parentIds string
+	optional  bool
 }
 
 // @llr REQ-TRAQ-SWL-8, REQ-TRAQ-SWL-9
@@ -52,6 +53,7 @@ func LookFor(t *testing.T, repoName repos.RepoName, sourceFile string, tagsPerFi
 				found = true
 				assert.Equal(t, e.line, tag.Line)
 				assert.Equal(t, e.tag, tag.Tag)
+				assert.Equal(t, e.optional, tag.Optional)
 				if e.parentIds != "" {
 					assert.Equal(t, e.parentIds, strings.Join(tag.ParentIds, ","))
 				}
@@ -77,19 +79,19 @@ func TestTagCode(t *testing.T) {
 	expectedTags := []TagMatch{
 		{"SeparateCommentsForLLrs",
 			41,
-			""},
+			"", false},
 		{"operator []",
 			37,
-			""},
+			"", false},
 		{"enumerateObjects",
 			27,
-			""},
+			"", false},
 		{"getSegment",
 			17,
-			""},
+			"", false},
 		{"getNumberOfSegments",
 			13,
-			""},
+			"", false},
 	}
 	LookFor(t, repoName, "a.cc", tags, expectedTags)
 }
@@ -122,19 +124,19 @@ func TestReqGraph_ParseCode(t *testing.T) {
 	expectedTags := []TagMatch{
 		{"SeparateCommentsForLLrs",
 			41,
-			"REQ-TEST-SWL-15,REQ-TEST-SWL-13"},
+			"REQ-TEST-SWL-15,REQ-TEST-SWL-13", false},
 		{"operator []",
 			37,
-			"REQ-TEST-SWL-13,REQ-TEST-SWL-14"},
+			"REQ-TEST-SWL-13,REQ-TEST-SWL-14", false},
 		{"enumerateObjects",
 			27,
-			`REQ-TEST-SWL-13`},
+			`REQ-TEST-SWL-13`, false},
 		{"getSegment",
 			17,
-			`REQ-TEST-SWL-12`},
+			`REQ-TEST-SWL-12`, false},
 		{"getNumberOfSegments",
 			13,
-			`REQ-TEST-SWH-11`},
+			`REQ-TEST-SWH-11`, false},
 	}
 	LookFor(t, repoName, "a.cc", rg.CodeTags, expectedTags)
 

--- a/req.go
+++ b/req.go
@@ -176,8 +176,8 @@ func (rg *ReqGraph) addCertdocToGraph(repoName repos.RepoName, documentConfig *c
 // resolve walks the requirements graph and resolves the links between different levels of requirements
 // and with code tags. References to requirements within requirements text is checked as well as validity
 // of attributes against the schema for their document. Any errors encountered such as links to
-// non-existent requirements are returned.
-// @llr REQ-TRAQ-SWL-10, REQ-TRAQ-SWL-11, REQ-TRAQ-SWL-67
+// non-existent requirements are returned in a list of issues.
+// @llr REQ-TRAQ-SWL-10, REQ-TRAQ-SWL-11, REQ-TRAQ-SWL-67, REQ-TRAQ-SWL-69
 func (rg *ReqGraph) resolve() []Issue {
 	issues := make([]Issue, 0)
 
@@ -303,7 +303,7 @@ func (rg *ReqGraph) resolve() []Issue {
 				parentIds = knownSymbols[code.Symbol]
 			}
 
-			if len(parentIds) == 0 {
+			if len(parentIds) == 0 && !code.Optional {
 				issue := Issue{
 					Line:     code.Line,
 					Path:     code.CodeFile.Path,

--- a/testdata/libclangtest/code/a.cc
+++ b/testdata/libclangtest/code/a.cc
@@ -23,4 +23,7 @@ void doMoreThings() {}
 // @llr REQ-TEST-SWL-3
 void allReqsCovered() {}
 
+// @llr REQ-TEST-SWL-3
+using MyType = int;
+
 }  // namespace na::nb::nc


### PR DESCRIPTION
In some cases we want some code to be able to link to requirements without having to link to requirements. Such is the case of type aliases, which is often used to link to requirements for type traits and similar meta-programming code, but does not always need to link to requirements (it is also often used as simple type aliases for brevity).