### PR TITLE
Differentiate between implementation code and test code

### DIFF
--- a/certdocs/TRAQ-137-SRD.md
+++ b/certdocs/TRAQ-137-SRD.md
@@ -218,6 +218,17 @@ Reqtraq SHALL have a simple web interface that allows generation and filtering o
 - Verification: Test
 - Safety Impact: None
 
+#### REQ-TRAQ-SWH-19 Differentiate between tests and implementation
+
+Reqtraq SHALL differentiate between tests and implementation.
+
+##### Attributes:
+- Parents:
+- Rationale: This information is useful in order to detect issues with tested requirements that 
+are not implemented and to compute the test coverage of requirements.
+- Verification: Test
+- Safety Impact: None
+
 ## Appendix
 
 ### Deleted requirements

--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -156,6 +156,16 @@ linked requirements.
 - Verification: Test
 - Safety Impact: None
 
+#### REQ-TRAQ-SWL-70 Distinguish code and tests
+
+Reqtraq SHALL tag all code links with its type (implementation or tests) after parsing it.
+
+##### Attributes:
+- Parents: REQ-TRAQ-SWH-19
+- Rationale: 
+- Verification: Test
+- Safety Impact: None
+
 ### diff.go
 
 Functions which compare two requirements graphs and return a map-of-slice-of-strings structure which describe how they differ.
@@ -287,6 +297,28 @@ Reqtraq SHALL generate tables which map between source code functions (source fi
 ##### Attributes:
 - Parents: REQ-TRAQ-SWH-5
 - Rationale:
+- Verification: Test
+- Safety Impact: None
+
+#### REQ-TRAQ-SWL-71 Implementation Code traceablility tables
+
+Reqtraq SHALL generate tables which map between implementation in the form of source code functions 
+(source file + function name) and low-level software requirements.
+
+##### Attributes:
+- Parents: REQ-TRAQ-SWH-5, REQ-TRAQ-SWH-19
+- Rationale: 
+- Verification: Test
+- Safety Impact: None
+
+#### REQ-TRAQ-SWL-72 Test Code traceablility tables
+
+Reqtraq SHALL generate tables which map between tests in the form of source code functions 
+(source file + function name) and low-level software requirements.
+
+##### Attributes:
+- Parents: REQ-TRAQ-SWH-5, REQ-TRAQ-SWH-19
+- Rationale: 
 - Verification: Test
 - Safety Impact: None
 

--- a/clang_test.go
+++ b/clang_test.go
@@ -18,9 +18,9 @@ func TestTagCodeLibClang(t *testing.T) {
 	repos.RegisterRepository(repoName, repos.RepoPath(filepath.Join(string(repos.BaseRepoPath()), "testdata/libclangtest")))
 
 	codeFiles := []CodeFile{
-		{RepoName: repoName, Path: "code/a.cc"},
-		{RepoName: repoName, Path: "code/include/a.hh"},
-		{RepoName: repoName, Path: "test/a/a_test.cc"},
+		{RepoName: repoName, Path: "code/a.cc", Type: CodeTypeImplementation},
+		{RepoName: repoName, Path: "code/include/a.hh", Type: CodeTypeImplementation},
+		{RepoName: repoName, Path: "test/a/a_test.cc", Type: CodeTypeTests},
 	}
 
 	compilerArgs := []string{
@@ -47,7 +47,7 @@ func TestTagCodeLibClang(t *testing.T) {
 		{"cool", 113, "", false},
 		{"JustAFreeFunction", 119, "", false},
 	}
-	LookFor(t, repoName, "code/include/a.hh", tags, expectedTags)
+	LookFor(t, repoName, "code/include/a.hh", CodeTypeImplementation, tags, expectedTags)
 
 	expectedTags = []TagMatch{
 		{"hiddenFunction", 9, "", false},
@@ -56,14 +56,14 @@ func TestTagCodeLibClang(t *testing.T) {
 		{"allReqsCovered", 24, "", false},
 		{"MyType", 27, "", true},
 	}
-	LookFor(t, repoName, "code/a.cc", tags, expectedTags)
+	LookFor(t, repoName, "code/a.cc", CodeTypeImplementation, tags, expectedTags)
 
 	expectedTags = []TagMatch{
 		{"TestDoThings", 9, "", false},
 		{"TestDoMoreThings", 15, "", false},
 		{"TestAllReqsCovered", 21, "", false},
 	}
-	LookFor(t, repoName, "test/a/a_test.cc", tags, expectedTags)
+	LookFor(t, repoName, "test/a/a_test.cc", CodeTypeTests, tags, expectedTags)
 }
 
 // @llr REQ-TRAQ-SWL-36

--- a/code_test.go
+++ b/code_test.go
@@ -37,10 +37,11 @@ type TagMatch struct {
 }
 
 // @llr REQ-TRAQ-SWL-8, REQ-TRAQ-SWL-9
-func LookFor(t *testing.T, repoName repos.RepoName, sourceFile string, tagsPerFile map[CodeFile][]*Code, expectedTags []TagMatch) {
+func LookFor(t *testing.T, repoName repos.RepoName, sourceFile string, codeType CodeType, tagsPerFile map[CodeFile][]*Code, expectedTags []TagMatch) {
 	codeFile := CodeFile{
 		Path:     sourceFile,
 		RepoName: repoName,
+		Type:     codeType,
 	}
 	tags, ok := tagsPerFile[codeFile]
 	assert.True(t, ok)
@@ -54,6 +55,7 @@ func LookFor(t *testing.T, repoName repos.RepoName, sourceFile string, tagsPerFi
 				assert.Equal(t, e.line, tag.Line)
 				assert.Equal(t, e.tag, tag.Tag)
 				assert.Equal(t, e.optional, tag.Optional)
+				assert.Equal(t, codeFile, tag.CodeFile)
 				if e.parentIds != "" {
 					assert.Equal(t, e.parentIds, strings.Join(tag.ParentIds, ","))
 				}
@@ -70,7 +72,7 @@ func TestTagCode(t *testing.T) {
 	repoName := repos.RepoName("cproject1")
 	repos.RegisterRepository(repoName, repos.RepoPath(filepath.Join(string(repos.BaseRepoPath()), "testdata/cproject1")))
 
-	tags, err := CtagsCodeParser{}.tagCode(repoName, []CodeFile{{Path: "a.cc", RepoName: repoName}}, "", []string{})
+	tags, err := CtagsCodeParser{}.tagCode(repoName, []CodeFile{{Path: "a.cc", RepoName: repoName, Type: CodeTypeTests}}, "", []string{})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -93,7 +95,7 @@ func TestTagCode(t *testing.T) {
 			13,
 			"", false},
 	}
-	LookFor(t, repoName, "a.cc", tags, expectedTags)
+	LookFor(t, repoName, "a.cc", CodeTypeTests, tags, expectedTags)
 }
 
 // @llr REQ-TRAQ-SWL-8, REQ-TRAQ-SWL-9
@@ -138,7 +140,7 @@ func TestReqGraph_ParseCode(t *testing.T) {
 			13,
 			`REQ-TEST-SWH-11`, false},
 	}
-	LookFor(t, repoName, "a.cc", rg.CodeTags, expectedTags)
+	LookFor(t, repoName, "a.cc", CodeTypeImplementation, rg.CodeTags, expectedTags)
 
 	rg.Reqs["REQ-TEST-SWL-13"] = &Req{ID: "REQ-TEST-SWL-13", Document: &doc, RepoName: "cproject1"}
 	rg.Reqs["REQ-TEST-SWH-11"] = &Req{ID: "REQ-TEST-SWH-11", Document: &doc, RepoName: "cproject1"}

--- a/webapp.go
+++ b/webapp.go
@@ -162,6 +162,20 @@ var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"
 				</a>
 			</div>
 		</div>
+		<div>
+			<div>
+				<a href="/matrix?from=REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }}&to=CODE&code-type=impl">
+					REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }} -> IMPLEMENTATION
+				</a>
+			</div>
+		</div>
+		<div>
+			<div>
+				<a href="/matrix?from=REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }}&to=CODE&code-type=test">
+					REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }} -> TESTS
+				</a>
+			</div>
+		</div>
 	{{ end }}
 	</div>
 </div>
@@ -191,6 +205,21 @@ func parseReqSpecFromRequest(specString string) (config.ReqSpec, error) {
 		Prefix: config.ReqPrefix(parts[0]),
 		Level:  config.ReqLevel(parts[1]),
 	}, nil
+}
+
+// @llr REQ-TRAQ-SWL-37
+func getCodeType(request *http.Request) CodeType {
+	formValue := request.FormValue("code-type")
+	switch formValue {
+	case "any":
+		return CodeTypeAny
+	case "impl":
+		return CodeTypeImplementation
+	case "test":
+		return CodeTypeTests
+	}
+
+	return CodeTypeAny
 }
 
 // get provides the page information for a given request
@@ -302,7 +331,7 @@ func get(w http.ResponseWriter, r *http.Request) error {
 
 		to := r.FormValue("to")
 		if to == "CODE" {
-			return rg.GenerateCodeTraceTables(w, fromSpec)
+			return rg.GenerateCodeTraceTables(w, fromSpec, getCodeType(r))
 		}
 
 		toSpec, err := parseReqSpecFromRequest(to)


### PR DESCRIPTION
So far reqtraq treated all code equally, but this does not allow to detect issues like tested but unimplemented requirements, which should be automatically checked.

This change adds a CodeType tag to each CodeFile and allows the user to:
- Request a matrix with only LLR-Implementation links.
- Request a matrix with only LLR-Test links.
- Show the type of code in reports.
- Ensure that tested requirements are also implemented.