### PR TITLE
Make concept optional links for code tags

### DIFF
--- a/clang.go
+++ b/clang.go
@@ -122,6 +122,13 @@ func visitAstNodes(cursor clang.Cursor, repoName repos.RepoName, repoPath string
 		}
 
 		switch cursor.Kind() {
+		case clang.Cursor_UnexposedDecl:
+			// libclang exposes concepts via Cursor_UnexposedDecl
+			// concepts CAN have parent requirements but DO NOT HAVE TO.
+			storeTag(cursor, true)
+
+			return clang.ChildVisit_Continue
+
 		case clang.Cursor_ClassDecl, clang.Cursor_EnumDecl, clang.Cursor_StructDecl, clang.Cursor_ClassTemplate, clang.Cursor_ClassTemplatePartialSpecialization:
 			if !IsPublic(cursor) {
 				return clang.ChildVisit_Continue

--- a/clang_test.go
+++ b/clang_test.go
@@ -50,11 +50,12 @@ func TestTagCodeLibClang(t *testing.T) {
 	LookFor(t, repoName, "code/include/a.hh", CodeTypeImplementation, tags, expectedTags)
 
 	expectedTags = []TagMatch{
-		{"hiddenFunction", 9, "", false},
-		{"doThings", 15, "", false},
-		{"doMoreThings", 21, "", false},
-		{"allReqsCovered", 24, "", false},
-		{"MyType", 27, "", true},
+		{"hiddenFunction", 10, "", false},
+		{"doThings", 16, "", false},
+		{"doMoreThings", 22, "", false},
+		{"allReqsCovered", 25, "", false},
+		{"MyType", 28, "", true},
+		{"MyConcept", 32, "", true},
 	}
 	LookFor(t, repoName, "code/a.cc", CodeTypeImplementation, tags, expectedTags)
 

--- a/clang_test.go
+++ b/clang_test.go
@@ -56,6 +56,7 @@ func TestTagCodeLibClang(t *testing.T) {
 		{"allReqsCovered", 25, "", false},
 		{"MyType", 28, "", true},
 		{"MyConcept", 32, "", true},
+		{"AnotherMyConcept", 37, "", true},
 	}
 	LookFor(t, repoName, "code/a.cc", CodeTypeImplementation, tags, expectedTags)
 

--- a/matrices.go
+++ b/matrices.go
@@ -135,6 +135,10 @@ func (rg ReqGraph) codeOrderInfo() (info CodeOrderInfo) {
 	for file, tags := range rg.CodeTags {
 		files = append(files, file.String())
 		for _, codeTag := range tags {
+			if codeTag.Optional && len(codeTag.Parents) == 0 {
+				// Ignore optional tags with no linked requirements
+				continue
+			}
 			if info.fileIndexFactor < codeTag.Line {
 				info.fileIndexFactor = codeTag.Line
 			}
@@ -167,7 +171,8 @@ func (rg *ReqGraph) createCodeSWLMatrix(reqSpec config.ReqSpec, codeType CodeTyp
 					count++
 				}
 			}
-			if count == 0 {
+			// Ignore optional tags with no linked requirements
+			if count == 0 && !codeTag.Optional {
 				row := TableRow{newCodeTableCell(codeTag), nil}
 				items = append(items, row)
 			}

--- a/report.go
+++ b/report.go
@@ -233,7 +233,7 @@ func formatBodyAsHTML(txt string) template.HTML {
 	return template.HTML(out)
 }
 
-var reportTmpl = template.Must(template.Must(template.New("").Funcs(template.FuncMap{"formatBodyAsHTML": formatBodyAsHTML, "codeFileToString": codeFileToString, "isImpl": isImpl, "isTest": isTest}).Parse(headerFooterTmplText)).Parse(reportTmplText))
+var reportTmpl = template.Must(template.Must(template.New("").Funcs(template.FuncMap{"formatBodyAsHTML": formatBodyAsHTML, "codeFileToString": codeFileToString, "isImpl": isImpl, "isTest": isTest, "shouldShowTag": shouldShowTag}).Parse(headerFooterTmplText)).Parse(reportTmplText))
 
 // @llr REQ-TRAQ-SWL-12, REQ-TRAQ-SWL-13
 func codeFileToString(CodeFile CodeFile) string {
@@ -248,6 +248,11 @@ func isImpl(CodeFile CodeFile) bool {
 // @llr REQ-TRAQ-SWL-12, REQ-TRAQ-SWL-13
 func isTest(CodeFile CodeFile) bool {
 	return CodeFile.Type.Matches(CodeTypeTests)
+}
+
+// @llr REQ-TRAQ-SWL-12, REQ-TRAQ-SWL-13
+func shouldShowTag(code *Code) bool {
+	return !code.Optional || (len(code.Parents) != 0)
 }
 
 var reportTmplText = `
@@ -345,6 +350,7 @@ var reportTmplText = `
 	<ul style="list-style: none; padding: 0; margin: 0;">
 		{{ range .Reqs.CodeTags }}
 		{{ range . }}
+		{{ if shouldShowTag . }}
 			<li>
 				{{ if isImpl .CodeFile }}
 					<h3><a href="{{ .URL }}" target="_blank">Impl: {{ codeFileToString .CodeFile }} - {{ .Tag }}</a></h3>
@@ -392,6 +398,7 @@ var reportTmplText = `
 					{{ end }}
 				</ul>
 			</li>
+		{{ end }}
 		{{ end }}
 		{{ else }}
 			<li class="text-danger">Empty graph</li>
@@ -449,6 +456,7 @@ var reportTmplText = `
 	<ul style="list-style: none; padding: 0; margin: 0;">
 		{{ range .Reqs.CodeTags }}
 		{{ range . }}
+		{{ if shouldShowTag . }}
 			{{ range .Parents }}
 				{{ if .Matches $.Filter $.Diffs }}
 					{{ with ($.Once.Once .) }}
@@ -464,6 +472,7 @@ var reportTmplText = `
 						{{ end }}
 				{{ end }}
 			{{ end }}
+		{{ end }}
 		{{ end }}
 		{{ end }}
 	</ul>

--- a/testdata/libclangtest/code/a.cc
+++ b/testdata/libclangtest/code/a.cc
@@ -33,4 +33,9 @@ concept MyConcept = requires(T t) {
     { t++ } -> std::same_as<int>;
 };
 
+template <typename T>
+concept AnotherMyConcept = requires(T t) {
+    { t++ } -> std::same_as<int>;
+};
+
 }  // namespace na::nb::nc

--- a/testdata/libclangtest/code/a.cc
+++ b/testdata/libclangtest/code/a.cc
@@ -1,4 +1,5 @@
 #include <a.hh>
+#include <type_traits>
 
 namespace na::nb::nc {
 
@@ -25,5 +26,11 @@ void allReqsCovered() {}
 
 // @llr REQ-TEST-SWL-3
 using MyType = int;
+
+// @llr REQ-TEST-SWL-3
+template <typename T>
+concept MyConcept = requires(T t) {
+    { t++ } -> std::same_as<int>;
+};
 
 }  // namespace na::nb::nc


### PR DESCRIPTION
Given that normally we have requirements on concepts in `stdlib` this will be needed, even more so when reqtraq differentiates between impl and tests. 

Also make sure that optional code tags don't show up in reports or matrices if they do not link to parents.