### PR TITLE
Increase max-width CSS body tag

### DIFF
--- a/report.go
+++ b/report.go
@@ -177,7 +177,7 @@ var headerFooterTmplText = `
 			}
 			body {
 				font-family: Roboto, Arial, sans-serif;
-				max-width: 1200px;
+				max-width: 3000px;
 				margin-left: 5%;
 				margin-right: 5%;
 			}


### PR DESCRIPTION
This will still use smaller sizes when the size of the browser window is smaller, but allows to expand the content if the display size allows it, which is handy for code matrices, where rows can be quite long.