### PR TITLE
Allow structs, classes and enums to optionally link to requirements

### DIFF
--- a/clang.go
+++ b/clang.go
@@ -134,6 +134,9 @@ func visitAstNodes(cursor clang.Cursor, repoName repos.RepoName, repoPath string
 				return clang.ChildVisit_Continue
 			}
 
+			// Classes, Enums, and Structs CAN have parent requirements but DO NOT HAVE TO.
+			storeTag(cursor, true)
+
 			// Only recurse if there is a chance that we can find something of interest.
 			// In practice if the element is not public, there is no point in recursing
 			return clang.ChildVisit_Recurse

--- a/clang_test.go
+++ b/clang_test.go
@@ -35,15 +35,19 @@ func TestTagCodeLibClang(t *testing.T) {
 	assert.Equal(t, 3, len(tags))
 
 	expectedTags := []TagMatch{
+		{"SomeType", 8, "", true},
 		{"doThings", 17, "", false},
 		{"doMoreThings", 23, "", false},
+		{"Array", 26, "", true},
 		{"Array<T, N>", 38, "", false},
 		{"operator[]", 45, "", false},
 		{"ButThisIsPublic", 59, "", false},
+		{"A", 62, "", true},
 		{"StructMethodsArePublicByDefault", 66, "", false},
 		{"JustAFreeFunction", 75, "", false},
 		{"sort", 95, "", false},
 		{"sort", 89, "", false},
+		{"B", 101, "", true},
 		{"cool", 113, "", false},
 		{"JustAFreeFunction", 119, "", false},
 	}


### PR DESCRIPTION
Sometimes these have to be linked to requirements because there is nothing else to link (code might be automatically generated by the compiler like for comparing enums, there is no need of implementing `operator==`)