### PR TITLE
Fix libclang ignores extern C functions

### DIFF
--- a/clang.go
+++ b/clang.go
@@ -86,6 +86,11 @@ func visitAstNodes(cursor clang.Cursor, repoName repos.RepoName, repoPath string
 	code := map[string]map[uint]*Code{}
 
 	storeTag := func(cursor clang.Cursor, optional bool) {
+		if strings.TrimSpace(cursor.Spelling()) == "" {
+			// Ignore empty symbols
+			return
+		}
+
 		file, line, _, _ := cursor.Location().FileLocation()
 
 		// Try to get relative path to the repo
@@ -127,7 +132,7 @@ func visitAstNodes(cursor clang.Cursor, repoName repos.RepoName, repoPath string
 			// concepts CAN have parent requirements but DO NOT HAVE TO.
 			storeTag(cursor, true)
 
-			return clang.ChildVisit_Continue
+			return clang.ChildVisit_Recurse
 
 		case clang.Cursor_ClassDecl, clang.Cursor_EnumDecl, clang.Cursor_StructDecl, clang.Cursor_ClassTemplate, clang.Cursor_ClassTemplatePartialSpecialization:
 			if !IsPublic(cursor) {

--- a/clang_test.go
+++ b/clang_test.go
@@ -50,6 +50,7 @@ func TestTagCodeLibClang(t *testing.T) {
 		{"B", 101, "", true},
 		{"cool", 113, "", false},
 		{"JustAFreeFunction", 119, "", false},
+		{"ExternCFunc", 126, "", false},
 	}
 	LookFor(t, repoName, "code/include/a.hh", CodeTypeImplementation, tags, expectedTags)
 
@@ -61,6 +62,7 @@ func TestTagCodeLibClang(t *testing.T) {
 		{"MyType", 28, "", true},
 		{"MyConcept", 32, "", true},
 		{"AnotherMyConcept", 37, "", true},
+		{"externFunc", 42, "", false},
 	}
 	LookFor(t, repoName, "code/a.cc", CodeTypeImplementation, tags, expectedTags)
 

--- a/code_test.go
+++ b/code_test.go
@@ -62,7 +62,7 @@ func LookFor(t *testing.T, repoName repos.RepoName, sourceFile string, codeType 
 				break
 			}
 		}
-		assert.True(t, found)
+		assert.True(t, found, tag)
 	}
 }
 

--- a/testdata/libclangtest/code/a.cc
+++ b/testdata/libclangtest/code/a.cc
@@ -38,4 +38,15 @@ concept AnotherMyConcept = requires(T t) {
     { t++ } -> std::same_as<int>;
 };
 
+// @llr REQ-TEST-SWL-3
+extern "C" void externFunc();
+
+extern "C" {
+
+/**
+ * \llr REQ-TEST-SWL-2
+ */
+int ExternCVar;
+}
+
 }  // namespace na::nb::nc

--- a/testdata/libclangtest/code/include/a.hh
+++ b/testdata/libclangtest/code/include/a.hh
@@ -118,4 +118,12 @@ class B final {
 
 void JustAFreeFunction();
 
+extern "C" {
+
+/**
+ * \llr REQ-TEST-SWL-2
+ */
+void ExternCFunc();
+}
+
 }  // namespace na::nb::nc


### PR DESCRIPTION
Because apparently they are the child of some `UnexposedDecl` cursor...