### PR TITLE
Allow linking of requirements within a document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Reqtraq
 
 
-Reqtraq is an open source go tool for requirement management, as mandated by
-DO-178C.
+Reqtraq is an open source Go tool for requirement management.
 Reqtraq is designed to stay out of your way. It requires no user interaction for day-to-day tasks.
 Instead, it parses documents that are required in the certification process and extracts everything
 it needs from there.
@@ -63,13 +62,13 @@ Requirement REQ-TEST-SYS-1  Bidirectional tracing.
 #### Report generation
 In report tags such as 'Changelists' and 'Problem Reports' will not work if not integrated with a task manager such as Phrabricator etc. (currently supported for Phabricator; JIRA and others need to be added)
 ```
-$ reqtraq reportdown
+$ reqtraq report down
 2017/06/06 22:48:12 Creating ./req-down.html (this may take a while)...
 ...
 ```
 Filtering:
 ```
-$ reqtraq reportdown --id_filter=".*TEST-SYS.*"
+$ reqtraq report down --id_filter=".*TEST-SYS.*"
 2017/06/06 22:51:23 Creating ./req-down.html (this may take a while)...
 2017/06/06 22:51:41 Creating ./req-down-filtered.html (this may take a while)...
 ```

--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -880,14 +880,14 @@ A sample configuration file is shown below:
             "parent": {
                 "prefix": "TEST",
                 "level": "SWH"
-                "srcAttribute": {
-                    "name": "Item",
-                    "value": "^Item1$"
-                },
-                "dstAttribute": {
+                "parentAttribute": {
                     "name": "Item Allocation",
                     "value": "Item1"
-                 }
+                },
+                "childAttribute": {
+                    "name": "Item",
+                    "value": "^Item1$"
+                }
             },
             "attributes": [
                 {
@@ -929,7 +929,7 @@ Each document contains:
 requirements in the document will look like. A document with level `SWL` and prefix `TEST` will have
 requirements of the form `REQ-TEST-SWL-1`.
 - An optional parent. If requirements can be linked to parent requirements, this field contains one or more link
-specifications containing a `prefix` and `level` of the parent, plus optional source and destination attribute
+specifications containing a `prefix` and `level` of the parent, plus optional parent and child attribute
 filters to enforce linking on a subset of requirements. The parent also implies a `Parents` attribute will be
 added to the schema of the document.
 - An implementation, which consists of separated matchers for both code and tests. It accepts the

--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -928,12 +928,10 @@ Each document contains:
 - A requirement specification in terms of a `prefix` and `level`. Together they fully specify how the
 requirements in the document will look like. A document with level `SWL` and prefix `TEST` will have
 requirements of the form `REQ-TEST-SWL-1`.
-- An optional parent. If there is a parent document, it contains also a `prefix` and `level` with the
-specification of the parent so that requirements can be linked from children to parent. The parent may also
-include source and destination attribute filters to enforce linking on a subset of requirements. The parent also
-implies a `Parents` attribute with a filter for the requirement specification of the parent will be
+- An optional parent. If requirements can be linked to parent requirements, this field contains one or more link
+specifications containing a `prefix` and `level` of the parent, plus optional source and destination attribute
+filters to enforce linking on a subset of requirements. The parent also implies a `Parents` attribute will be
 added to the schema of the document.
-- An optional parents. If multiple parent links need to be specified.
 - An implementation, which consists of separated matchers for both code and tests. It accepts the
 following parameters:
   - `codeParser`: The selected code parser. Defaults to `ctags`. Available values are `ctags` and `clang`.

--- a/certdocs/TRAQ-138-SDD.md
+++ b/certdocs/TRAQ-138-SDD.md
@@ -53,7 +53,7 @@ Reqtraq has the following outputs:
 Reqtraq uses a configuration file to determine:
 - What documents are part of the requirements identification. Reqtraq will parse all certification documents listed in the configuration and extract requirements from all of them.
 - What kind of requirements can be found in each of these documents. Reqtraq must categorize requirements according to their level and prefix.
-- What are the relationships between documents and requirements. Requirements at different levels have a parent-children relationship that is specified by the reqtraq configuration.
+- What are the relationships between documents and requirements. Requirements have a parent-child relationship that is specified by the reqtraq configuration.
 - Where the implementation of low-level-requirements is located. Reqtraq must check all implentation and tests in order to complete its traceability report.
 - What attributes are allowed by the reqtraq schema and their allowed range of values. This may depend on the document or requirement level.
 
@@ -288,11 +288,11 @@ Reqtraq SHALL provide a command line option to show tool usage.
 
 ### matrices.go
 
-Functions which generate trace matrix tables between different levels of requirements and source code.
+Functions which generate trace matrix tables between different requirements and source code.
 
 #### REQ-TRAQ-SWL-14 Requirement traceability tables
 
-Reqtraq SHALL generate tables which map between two adjacent level of requirements (e.g. system to high-Level software requirements).
+Reqtraq SHALL generate tables which map between parent-child requirements, as defined in the requirement configuration.
 
 ##### Attributes:
 - Parents: REQ-TRAQ-SWH-5
@@ -702,6 +702,16 @@ Reqtraq SHALL check that the requirements referred to in each markdown document 
 - Verification: Test
 - Safety Impact: None
 
+#### REQ-TRAQ-SWL-76 Valid parent links
+
+Reqtraq SHALL check that the parent links for each requirement conform to the associated schema.
+
+##### Attributes:
+- Parents: REQ-TRAQ-SWH-3
+- Rationale:
+- Verification: Test
+- Safety Impact: None
+
 #### REQ-TRAQ-SWL-11 Invalid references to deleted requirements
 
 Reqtraq SHALL ensure that links are not made to deleted requirements.
@@ -870,6 +880,14 @@ A sample configuration file is shown below:
             "parent": {
                 "prefix": "TEST",
                 "level": "SWH"
+                "srcAttribute": {
+                    "name": "Item",
+                    "value": "^Item1$"
+                },
+                "dstAttribute": {
+                    "name": "Item Allocation",
+                    "value": "Item1"
+                 }
             },
             "attributes": [
                 {
@@ -911,9 +929,11 @@ Each document contains:
 requirements in the document will look like. A document with level `SWL` and prefix `TEST` will have
 requirements of the form `REQ-TEST-SWL-1`.
 - An optional parent. If there is a parent document, it contains also a `prefix` and `level` with the
-specification of the parent so that requirements can be linked from children to parent. The parent also
+specification of the parent so that requirements can be linked from children to parent. The parent may also
+include source and destination attribute filters to enforce linking on a subset of requirements. The parent also
 implies a `Parents` attribute with a filter for the requirement specification of the parent will be
 added to the schema of the document.
+- An optional parents. If multiple parent links need to be specified.
 - An implementation, which consists of separated matchers for both code and tests. It accepts the
 following parameters:
   - `codeParser`: The selected code parser. Defaults to `ctags`. Available values are `ctags` and `clang`.
@@ -970,8 +990,8 @@ Reqtraq SHALL provide a method to find a certification document inside any of th
 
 #### REQ-TRAQ-SWL-55 Find linked documents
 
-Reqtraq SHALL provide a method to find linked requirements across different documents that share a
-parent/child relationship.
+Reqtraq SHALL provide a method to find linked requirements within documents or across different documents,
+that share a parent/child relationship.
 
 ##### Attributes:
 - Parents: REQ-TRAQ-SWH-15

--- a/config/config.go
+++ b/config/config.go
@@ -287,6 +287,8 @@ func (op *jsonParents) UnmarshalJSON(data []byte) error {
 		return errors.New("no bytes to unmarshal")
 	}
 
+	*op = jsonParents{}
+
 	// Use the first character to determine the type
 	switch data[0] {
 	case '{':

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,6 +49,7 @@ func TestConfig_ParseConfig(t *testing.T) {
 				Prefix: ReqPrefix("TEST"),
 				Level:  ReqLevel("SYS"),
 			},
+			LinkSpecs: nil,
 			Schema: Schema{
 				Requirements: regexp.MustCompile(`(REQ|ASM)-TEST-SYS-(\d+)`),
 				Attributes: map[string]*Attribute{
@@ -77,9 +78,21 @@ func TestConfig_ParseConfig(t *testing.T) {
 				Prefix: ReqPrefix("TEST"),
 				Level:  ReqLevel("SWH"),
 			},
-			ParentReqSpec: ReqSpec{
-				Prefix: ReqPrefix("TEST"),
-				Level:  ReqLevel("SYS"),
+			LinkSpecs: []LinkSpec{
+				{
+					Src: ReqSpec{
+						Prefix:  ReqPrefix("TEST"),
+						Level:   ReqLevel("SWH"),
+						Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+						AttrKey: "",
+						AttrVal: regexp.MustCompile(".*")},
+					Dst: ReqSpec{
+						Prefix:  ReqPrefix("TEST"),
+						Level:   ReqLevel("SYS"),
+						Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+						AttrKey: "",
+						AttrVal: regexp.MustCompile(".*")},
+				},
 			},
 			Schema: Schema{
 				Requirements: regexp.MustCompile(`(REQ|ASM)-TEST-SWH-(\d+)`),
@@ -88,7 +101,7 @@ func TestConfig_ParseConfig(t *testing.T) {
 					"VERIFICATION":  commonAttributes["VERIFICATION"],
 					"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 					"PARENTS": {
-						Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
+						Value: regexp.MustCompile(`.*`),
 						Type:  AttributeAny,
 					},
 				},
@@ -117,23 +130,32 @@ func TestConfig_ParseConfig(t *testing.T) {
 	assert.Equal(t, config.Repos["projectB"].Documents[0].Path, "TEST-138-SDD.md")
 	assert.Equal(t, config.Repos["projectB"].Documents[0].ReqSpec.Prefix, ReqPrefix("TEST"))
 	assert.Equal(t, config.Repos["projectB"].Documents[0].ReqSpec.Level, ReqLevel("SWL"))
-	assert.Equal(t, config.Repos["projectB"].Documents[0].ParentReqSpec, ReqSpec{Prefix: ReqPrefix("TEST"), Level: ReqLevel("SWH")})
+	assert.Equal(t, config.Repos["projectB"].Documents[0].LinkSpecs, []LinkSpec{
+		{
+			Src: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWL"),
+				Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+			Dst: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWH"),
+				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+		},
+	})
 	assert.Equal(t, config.Repos["projectB"].Documents[0].Schema.Requirements, regexp.MustCompile(`(REQ|ASM)-TEST-SWL-(\d+)`))
 	assert.Equal(t, config.Repos["projectB"].Documents[0].Schema.Attributes, map[string]*Attribute{
 		"RATIONALE":     commonAttributes["RATIONALE"],
 		"VERIFICATION":  commonAttributes["VERIFICATION"],
 		"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 		"PARENTS": {
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
+			Value: regexp.MustCompile(`.*`),
 			Type:  AttributeAny,
 		},
 	})
-	assert.Equal(t, *config.Repos["projectB"].Documents[0].Schema.Attributes["PARENTS"],
-		Attribute{
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
-			Type:  AttributeAny,
-		},
-	)
 	assert.Equal(t, *config.Repos["projectB"].Documents[0].Schema.AsmAttributes["PARENTS"],
 		Attribute{
 			Value: regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
@@ -157,23 +179,32 @@ func TestConfig_ParseConfig(t *testing.T) {
 	assert.Equal(t, config.Repos["projectC"].Documents[0].Path, "TST-138-SDD.md")
 	assert.Equal(t, config.Repos["projectC"].Documents[0].ReqSpec.Prefix, ReqPrefix("TST"))
 	assert.Equal(t, config.Repos["projectC"].Documents[0].ReqSpec.Level, ReqLevel("SWL"))
-	assert.Equal(t, config.Repos["projectC"].Documents[0].ParentReqSpec, ReqSpec{Prefix: ReqPrefix("TEST"), Level: ReqLevel("SWH")})
+	assert.Equal(t, config.Repos["projectC"].Documents[0].LinkSpecs, []LinkSpec{
+		{
+			Src: ReqSpec{
+				Prefix:  ReqPrefix("TST"),
+				Level:   ReqLevel("SWL"),
+				Re:      regexp.MustCompile("REQ-TST-SWL-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+			Dst: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWH"),
+				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+		},
+	})
 	assert.Equal(t, config.Repos["projectC"].Documents[0].Schema.Requirements, regexp.MustCompile(`(REQ|ASM)-TST-SWL-(\d+)`))
 	assert.Equal(t, config.Repos["projectC"].Documents[0].Schema.Attributes, map[string]*Attribute{
 		"RATIONALE":     commonAttributes["RATIONALE"],
 		"VERIFICATION":  commonAttributes["VERIFICATION"],
 		"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 		"PARENTS": {
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
+			Value: regexp.MustCompile(`.*`),
 			Type:  AttributeAny,
 		},
 	})
-	assert.Equal(t, *config.Repos["projectC"].Documents[0].Schema.Attributes["PARENTS"],
-		Attribute{
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
-			Type:  AttributeAny,
-		},
-	)
 	assert.Equal(t, *config.Repos["projectC"].Documents[0].Schema.AsmAttributes["PARENTS"],
 		Attribute{
 			Value: regexp.MustCompile("REQ-TST-SWL-(\\d+)"),
@@ -233,6 +264,7 @@ func TestConfig_ParseConfigOnlyDirectDeps(t *testing.T) {
 				Prefix: ReqPrefix("TEST"),
 				Level:  ReqLevel("SYS"),
 			},
+			LinkSpecs: nil,
 			Schema: Schema{
 				Requirements: regexp.MustCompile(`(REQ|ASM)-TEST-SYS-(\d+)`),
 				Attributes: map[string]*Attribute{
@@ -261,9 +293,21 @@ func TestConfig_ParseConfigOnlyDirectDeps(t *testing.T) {
 				Prefix: ReqPrefix("TEST"),
 				Level:  ReqLevel("SWH"),
 			},
-			ParentReqSpec: ReqSpec{
-				Prefix: ReqPrefix("TEST"),
-				Level:  ReqLevel("SYS"),
+			LinkSpecs: []LinkSpec{
+				{
+					Src: ReqSpec{
+						Prefix:  ReqPrefix("TEST"),
+						Level:   ReqLevel("SWH"),
+						Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+						AttrKey: "",
+						AttrVal: regexp.MustCompile(".*")},
+					Dst: ReqSpec{
+						Prefix:  ReqPrefix("TEST"),
+						Level:   ReqLevel("SYS"),
+						Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+						AttrKey: "",
+						AttrVal: regexp.MustCompile(".*")},
+				},
 			},
 			Schema: Schema{
 				Requirements: regexp.MustCompile(`(REQ|ASM)-TEST-SWH-(\d+)`),
@@ -272,7 +316,7 @@ func TestConfig_ParseConfigOnlyDirectDeps(t *testing.T) {
 					"VERIFICATION":  commonAttributes["VERIFICATION"],
 					"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 					"PARENTS": {
-						Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
+						Value: regexp.MustCompile(`.*`),
 						Type:  AttributeAny,
 					},
 				},
@@ -301,23 +345,32 @@ func TestConfig_ParseConfigOnlyDirectDeps(t *testing.T) {
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].Path, "TEST-138-SDD.md")
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].ReqSpec.Prefix, ReqPrefix("TEST"))
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].ReqSpec.Level, ReqLevel("SWL"))
-	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].ParentReqSpec, ReqSpec{Prefix: ReqPrefix("TEST"), Level: ReqLevel("SWH")})
+	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].LinkSpecs, []LinkSpec{
+		{
+			Src: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWL"),
+				Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+			Dst: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWH"),
+				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+		},
+	})
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].Schema.Requirements, regexp.MustCompile(`(REQ|ASM)-TEST-SWL-(\d+)`))
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].Schema.Attributes, map[string]*Attribute{
 		"RATIONALE":     commonAttributes["RATIONALE"],
 		"VERIFICATION":  commonAttributes["VERIFICATION"],
 		"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 		"PARENTS": {
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
+			Value: regexp.MustCompile(`.*`),
 			Type:  AttributeAny,
 		},
 	})
-	assert.Equal(t, *parsedConfig.Repos["projectB"].Documents[0].Schema.Attributes["PARENTS"],
-		Attribute{
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
-			Type:  AttributeAny,
-		},
-	)
 	assert.Equal(t, *parsedConfig.Repos["projectB"].Documents[0].Schema.AsmAttributes["PARENTS"],
 		Attribute{
 			Value: regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
@@ -375,6 +428,7 @@ func TestConfig_ParseConfigLibClang(t *testing.T) {
 				Prefix: ReqPrefix("TEST"),
 				Level:  ReqLevel("SYS"),
 			},
+			LinkSpecs: nil,
 			Schema: Schema{
 				Requirements: regexp.MustCompile(`(REQ|ASM)-TEST-SYS-(\d+)`),
 				Attributes: map[string]*Attribute{
@@ -405,9 +459,21 @@ func TestConfig_ParseConfigLibClang(t *testing.T) {
 				Prefix: ReqPrefix("TEST"),
 				Level:  ReqLevel("SWH"),
 			},
-			ParentReqSpec: ReqSpec{
-				Prefix: ReqPrefix("TEST"),
-				Level:  ReqLevel("SYS"),
+			LinkSpecs: []LinkSpec{
+				{
+					Src: ReqSpec{
+						Prefix:  ReqPrefix("TEST"),
+						Level:   ReqLevel("SWH"),
+						Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+						AttrKey: "",
+						AttrVal: regexp.MustCompile(".*")},
+					Dst: ReqSpec{
+						Prefix:  ReqPrefix("TEST"),
+						Level:   ReqLevel("SYS"),
+						Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+						AttrKey: "",
+						AttrVal: regexp.MustCompile(".*")},
+				},
 			},
 			Schema: Schema{
 				Requirements: regexp.MustCompile(`(REQ|ASM)-TEST-SWH-(\d+)`),
@@ -416,7 +482,7 @@ func TestConfig_ParseConfigLibClang(t *testing.T) {
 					"VERIFICATION":  commonAttributes["VERIFICATION"],
 					"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 					"PARENTS": {
-						Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
+						Value: regexp.MustCompile(`.*`),
 						Type:  AttributeAny,
 					},
 				},
@@ -441,14 +507,29 @@ func TestConfig_ParseConfigLibClang(t *testing.T) {
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].Path, "TEST-138-SDD.md")
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].ReqSpec.Prefix, ReqPrefix("TEST"))
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].ReqSpec.Level, ReqLevel("SWL"))
-	assert.Equal(t, config.Repos["libclangtest"].Documents[2].ParentReqSpec, ReqSpec{Prefix: ReqPrefix("TEST"), Level: ReqLevel("SWH")})
+	assert.Equal(t, config.Repos["libclangtest"].Documents[2].LinkSpecs, []LinkSpec{
+		{
+			Src: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWL"),
+				Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+			Dst: ReqSpec{
+				Prefix:  ReqPrefix("TEST"),
+				Level:   ReqLevel("SWH"),
+				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+				AttrKey: "",
+				AttrVal: regexp.MustCompile(".*")},
+		},
+	})
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].Schema.Requirements, regexp.MustCompile(`(REQ|ASM)-TEST-SWL-(\d+)`))
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].Schema.Attributes, map[string]*Attribute{
 		"RATIONALE":     commonAttributes["RATIONALE"],
 		"VERIFICATION":  commonAttributes["VERIFICATION"],
 		"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 		"PARENTS": {
-			Value: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
+			Value: regexp.MustCompile(`.*`),
 			Type:  AttributeAny,
 		},
 	})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -80,13 +80,13 @@ func TestConfig_ParseConfig(t *testing.T) {
 			},
 			LinkSpecs: []LinkSpec{
 				{
-					Src: ReqSpec{
+					Child: ReqSpec{
 						Prefix:  ReqPrefix("TEST"),
 						Level:   ReqLevel("SWH"),
 						Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 						AttrKey: "",
 						AttrVal: regexp.MustCompile(".*")},
-					Dst: ReqSpec{
+					Parent: ReqSpec{
 						Prefix:  ReqPrefix("TEST"),
 						Level:   ReqLevel("SYS"),
 						Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
@@ -132,13 +132,13 @@ func TestConfig_ParseConfig(t *testing.T) {
 	assert.Equal(t, config.Repos["projectB"].Documents[0].ReqSpec.Level, ReqLevel("SWL"))
 	assert.Equal(t, config.Repos["projectB"].Documents[0].LinkSpecs, []LinkSpec{
 		{
-			Src: ReqSpec{
+			Child: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWL"),
 				Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
 				AttrKey: "",
 				AttrVal: regexp.MustCompile(".*")},
-			Dst: ReqSpec{
+			Parent: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWH"),
 				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
@@ -181,13 +181,13 @@ func TestConfig_ParseConfig(t *testing.T) {
 	assert.Equal(t, config.Repos["projectC"].Documents[0].ReqSpec.Level, ReqLevel("SWL"))
 	assert.Equal(t, config.Repos["projectC"].Documents[0].LinkSpecs, []LinkSpec{
 		{
-			Src: ReqSpec{
+			Child: ReqSpec{
 				Prefix:  ReqPrefix("TST"),
 				Level:   ReqLevel("SWL"),
 				Re:      regexp.MustCompile("REQ-TST-SWL-(\\d+)"),
 				AttrKey: "",
 				AttrVal: regexp.MustCompile(".*")},
-			Dst: ReqSpec{
+			Parent: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWH"),
 				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
@@ -295,13 +295,13 @@ func TestConfig_ParseConfigOnlyDirectDeps(t *testing.T) {
 			},
 			LinkSpecs: []LinkSpec{
 				{
-					Src: ReqSpec{
+					Child: ReqSpec{
 						Prefix:  ReqPrefix("TEST"),
 						Level:   ReqLevel("SWH"),
 						Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 						AttrKey: "",
 						AttrVal: regexp.MustCompile(".*")},
-					Dst: ReqSpec{
+					Parent: ReqSpec{
 						Prefix:  ReqPrefix("TEST"),
 						Level:   ReqLevel("SYS"),
 						Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
@@ -347,13 +347,13 @@ func TestConfig_ParseConfigOnlyDirectDeps(t *testing.T) {
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].ReqSpec.Level, ReqLevel("SWL"))
 	assert.Equal(t, parsedConfig.Repos["projectB"].Documents[0].LinkSpecs, []LinkSpec{
 		{
-			Src: ReqSpec{
+			Child: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWL"),
 				Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
 				AttrKey: "",
 				AttrVal: regexp.MustCompile(".*")},
-			Dst: ReqSpec{
+			Parent: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWH"),
 				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
@@ -461,13 +461,13 @@ func TestConfig_ParseConfigLibClang(t *testing.T) {
 			},
 			LinkSpecs: []LinkSpec{
 				{
-					Src: ReqSpec{
+					Child: ReqSpec{
 						Prefix:  ReqPrefix("TEST"),
 						Level:   ReqLevel("SWH"),
 						Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 						AttrKey: "",
 						AttrVal: regexp.MustCompile(".*")},
-					Dst: ReqSpec{
+					Parent: ReqSpec{
 						Prefix:  ReqPrefix("TEST"),
 						Level:   ReqLevel("SYS"),
 						Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
@@ -509,13 +509,13 @@ func TestConfig_ParseConfigLibClang(t *testing.T) {
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].ReqSpec.Level, ReqLevel("SWL"))
 	assert.Equal(t, config.Repos["libclangtest"].Documents[2].LinkSpecs, []LinkSpec{
 		{
-			Src: ReqSpec{
+			Child: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWL"),
 				Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
 				AttrKey: "",
 				AttrVal: regexp.MustCompile(".*")},
-			Dst: ReqSpec{
+			Parent: ReqSpec{
 				Prefix:  ReqPrefix("TEST"),
 				Level:   ReqLevel("SWH"),
 				Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ and the source code for references to them.`,
 var reqtraqConfig *config.Config
 
 // Runs the root command and defers the cleanup of the temporary directories until it exits
-// @llr REQ-TRAQ-SWL-59
+// @llr REQ-TRAQ-SWL-32, REQ-TRAQ-SWL-59
 func Execute() error {
 	defer repos.CleanupTemporaryDirectories()
 

--- a/main_test.go
+++ b/main_test.go
@@ -76,6 +76,18 @@ func TestValidateCreateReqGraphMarkdown(t *testing.T) {
 							Prefix: "TEST",
 							Level:  "SWH",
 						},
+						LinkSpecs: []config.LinkSpec{
+							{
+								Src: config.ReqSpec{
+									Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+									AttrKey: "",
+									AttrVal: regexp.MustCompile(".*")},
+								Dst: config.ReqSpec{
+									Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+									AttrKey: "",
+									AttrVal: regexp.MustCompile(".*")},
+							},
+						},
 						Schema: config.Schema{
 							Requirements: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
 							Attributes: map[string]*config.Attribute{
@@ -84,7 +96,7 @@ func TestValidateCreateReqGraphMarkdown(t *testing.T) {
 								"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 								"PARENTS": {
 									Type:  config.AttributeAny,
-									Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
+									Value: regexp.MustCompile(`.*`),
 								},
 							},
 						},
@@ -98,6 +110,18 @@ func TestValidateCreateReqGraphMarkdown(t *testing.T) {
 							Prefix: "TEST",
 							Level:  "SWL",
 						},
+						LinkSpecs: []config.LinkSpec{
+							{
+								Src: config.ReqSpec{
+									Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+									AttrKey: "",
+									AttrVal: regexp.MustCompile(".*")},
+								Dst: config.ReqSpec{
+									Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+									AttrKey: "",
+									AttrVal: regexp.MustCompile(".*")},
+							},
+						},
 						Schema: config.Schema{
 							Requirements: regexp.MustCompile(`REQ-TEST-SWL-(\d+)`),
 							Attributes: map[string]*config.Attribute{
@@ -106,7 +130,7 @@ func TestValidateCreateReqGraphMarkdown(t *testing.T) {
 								"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 								"PARENTS": {
 									Type:  config.AttributeAny,
-									Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
+									Value: regexp.MustCompile(`.*`),
 								},
 							},
 						},
@@ -194,6 +218,18 @@ func TestValidateCheckReqReferencesMarkdown(t *testing.T) {
 							Prefix: "TEST",
 							Level:  "SWH",
 						},
+						LinkSpecs: []config.LinkSpec{
+							{
+								Src: config.ReqSpec{
+									Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+									AttrKey: "",
+									AttrVal: regexp.MustCompile(".*")},
+								Dst: config.ReqSpec{
+									Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+									AttrKey: "",
+									AttrVal: regexp.MustCompile(".*")},
+							},
+						},
 						Schema: config.Schema{
 							Requirements: regexp.MustCompile(`REQ-TEST-SWH-(\d+)`),
 							Attributes: map[string]*config.Attribute{
@@ -202,7 +238,7 @@ func TestValidateCheckReqReferencesMarkdown(t *testing.T) {
 								"SAFETY IMPACT": commonAttributes["SAFETY IMPACT"],
 								"PARENTS": {
 									Type:  config.AttributeAny,
-									Value: regexp.MustCompile(`REQ-TEST-SYS-(\d+)`),
+									Value: regexp.MustCompile(`.*`),
 								},
 							},
 						},
@@ -271,6 +307,29 @@ func TestValidateMultipleRepos(t *testing.T) {
 	expected := `Requirement 'ASM-TEST-SWH-3' is missing attribute 'VALIDATION'.
 Requirement 'ASM-TEST-SWH-3' has unknown attribute 'VERIFICATION'.
 Requirement 'ASM-TEST-SWH-2' has invalid value 'REQ-TEST-SYS-2' in attribute 'PARENTS'.
+WARNING. Validation failed`
+
+	checkValidateError(t, actual, expected)
+}
+
+// @llr REQ-TRAQ-SWL-36
+func TestValidateMultipleLevelDoc(t *testing.T) {
+	// Actually read configuration from repositories
+	repos.ClearAllRepositories()
+	repos.RegisterRepository(repos.RepoName("multiple_level_doc"), repos.RepoPath("testdata/multiple_level_doc"))
+
+	// Make sure the child can reach the parent
+	config, err := config.ParseConfig("testdata/multiple_level_doc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := RunValidate(t, &config)
+	assert.Empty(t, err, "Got unexpected error")
+
+	expected := `Requirement 'REQ-TEST-SYS-6' has invalid parent link ID 'REQ-TEST-SYS-1'.
+Requirement 'REQ-TEST-SYS-7' has invalid parent link ID 'REQ-TEST-SYS-3' with attribute value 'COMPONENT ALLOCATION'=='Component1'.
+Requirement 'REQ-TEST-SWH-3' has invalid parent link ID 'REQ-TEST-SYS-1' with attribute value 'COMPONENT ALLOCATION'=='System'.
 WARNING. Validation failed`
 
 	checkValidateError(t, actual, expected)

--- a/main_test.go
+++ b/main_test.go
@@ -78,11 +78,11 @@ func TestValidateCreateReqGraphMarkdown(t *testing.T) {
 						},
 						LinkSpecs: []config.LinkSpec{
 							{
-								Src: config.ReqSpec{
+								Child: config.ReqSpec{
 									Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 									AttrKey: "",
 									AttrVal: regexp.MustCompile(".*")},
-								Dst: config.ReqSpec{
+								Parent: config.ReqSpec{
 									Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
 									AttrKey: "",
 									AttrVal: regexp.MustCompile(".*")},
@@ -112,11 +112,11 @@ func TestValidateCreateReqGraphMarkdown(t *testing.T) {
 						},
 						LinkSpecs: []config.LinkSpec{
 							{
-								Src: config.ReqSpec{
+								Child: config.ReqSpec{
 									Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
 									AttrKey: "",
 									AttrVal: regexp.MustCompile(".*")},
-								Dst: config.ReqSpec{
+								Parent: config.ReqSpec{
 									Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
 									AttrKey: "",
 									AttrVal: regexp.MustCompile(".*")},
@@ -220,11 +220,11 @@ func TestValidateCheckReqReferencesMarkdown(t *testing.T) {
 						},
 						LinkSpecs: []config.LinkSpec{
 							{
-								Src: config.ReqSpec{
+								Child: config.ReqSpec{
 									Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 									AttrKey: "",
 									AttrVal: regexp.MustCompile(".*")},
-								Dst: config.ReqSpec{
+								Parent: config.ReqSpec{
 									Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
 									AttrKey: "",
 									AttrVal: regexp.MustCompile(".*")},

--- a/matrices_test.go
+++ b/matrices_test.go
@@ -81,13 +81,13 @@ func TestReqGraph_createMatrix(t *testing.T) {
 		ReqSpec: swhReqSpec,
 		LinkSpecs: []config.LinkSpec{
 			{
-				Src: config.ReqSpec{
+				Child: config.ReqSpec{
 					Prefix:  config.ReqPrefix("TEST"),
 					Level:   config.ReqLevel("SWH"),
 					Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 					AttrKey: "",
 					AttrVal: regexp.MustCompile(".*")},
-				Dst: config.ReqSpec{
+				Parent: config.ReqSpec{
 					Prefix:  config.ReqPrefix("TEST"),
 					Level:   config.ReqLevel("SYS"),
 					Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
@@ -125,13 +125,13 @@ func TestReqGraph_createMatrix(t *testing.T) {
 		ReqSpec: swlReqSpec,
 		LinkSpecs: []config.LinkSpec{
 			{
-				Src: config.ReqSpec{
+				Child: config.ReqSpec{
 					Prefix:  config.ReqPrefix("TEST"),
 					Level:   config.ReqLevel("SWL"),
 					Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
 					AttrKey: "",
 					AttrVal: regexp.MustCompile(".*")},
-				Dst: config.ReqSpec{
+				Parent: config.ReqSpec{
 					Prefix:  config.ReqPrefix("TEST"),
 					Level:   config.ReqLevel("SWH"),
 					Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),

--- a/matrices_test.go
+++ b/matrices_test.go
@@ -34,16 +34,25 @@ func TestReqGraph_createMatrix(t *testing.T) {
 	rg := &ReqGraph{Reqs: make(map[string]*Req)}
 
 	sysReqSpec := config.ReqSpec{
-		Prefix: "SYS",
-		Level:  "TEST",
+		Prefix:  "SYS",
+		Level:   "TEST",
+		Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+		AttrKey: "",
+		AttrVal: regexp.MustCompile(".*"),
 	}
 	swhReqSpec := config.ReqSpec{
-		Prefix: "SWH",
-		Level:  "TEST",
+		Prefix:  "SWH",
+		Level:   "TEST",
+		Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+		AttrKey: "",
+		AttrVal: regexp.MustCompile(".*"),
 	}
 	swlReqSpec := config.ReqSpec{
-		Prefix: "SWL",
-		Level:  "TEST",
+		Prefix:  "SWL",
+		Level:   "TEST",
+		Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+		AttrKey: "",
+		AttrVal: regexp.MustCompile(".*"),
 	}
 
 	sysDoc := config.Document{
@@ -68,9 +77,24 @@ func TestReqGraph_createMatrix(t *testing.T) {
 	}
 
 	srdDoc := config.Document{
-		Path:          "path/to/srd.md",
-		ParentReqSpec: sysReqSpec,
-		ReqSpec:       swhReqSpec,
+		Path:    "path/to/srd.md",
+		ReqSpec: swhReqSpec,
+		LinkSpecs: []config.LinkSpec{
+			{
+				Src: config.ReqSpec{
+					Prefix:  config.ReqPrefix("TEST"),
+					Level:   config.ReqLevel("SWH"),
+					Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+					AttrKey: "",
+					AttrVal: regexp.MustCompile(".*")},
+				Dst: config.ReqSpec{
+					Prefix:  config.ReqPrefix("TEST"),
+					Level:   config.ReqLevel("SYS"),
+					Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+					AttrKey: "",
+					AttrVal: regexp.MustCompile(".*")},
+			},
+		},
 		Schema: config.Schema{
 			Requirements: regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 			Attributes:   make(map[string]*config.Attribute),
@@ -97,9 +121,24 @@ func TestReqGraph_createMatrix(t *testing.T) {
 	}
 
 	sddDoc := config.Document{
-		Path:          "path/to/sdd.md",
-		ParentReqSpec: swhReqSpec,
-		ReqSpec:       swlReqSpec,
+		Path:    "path/to/sdd.md",
+		ReqSpec: swlReqSpec,
+		LinkSpecs: []config.LinkSpec{
+			{
+				Src: config.ReqSpec{
+					Prefix:  config.ReqPrefix("TEST"),
+					Level:   config.ReqLevel("SWL"),
+					Re:      regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
+					AttrKey: "",
+					AttrVal: regexp.MustCompile(".*")},
+				Dst: config.ReqSpec{
+					Prefix:  config.ReqPrefix("TEST"),
+					Level:   config.ReqLevel("SWH"),
+					Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+					AttrKey: "",
+					AttrVal: regexp.MustCompile(".*")},
+			},
+		},
 		Schema: config.Schema{
 			Requirements: regexp.MustCompile("REQ-TEST-SWL-(\\d+)"),
 			Attributes:   make(map[string]*config.Attribute),

--- a/report.go
+++ b/report.go
@@ -62,7 +62,7 @@ func (rg ReqGraph) ReportIssuesFiltered(w io.Writer, filter *ReqFilter, diffs ma
 func (rg ReqGraph) OrdsByPosition() []*Req {
 	var r []*Req
 	for _, v := range rg.Reqs {
-		if !v.Document.HasParent() && len(v.ParentIds) == 0 {
+		if v.Document.LinkSpecs == nil && len(v.ParentIds) == 0 {
 			r = append(r, v)
 		}
 	}

--- a/req.go
+++ b/req.go
@@ -641,28 +641,28 @@ func (r *Req) checkAttributes() []Issue {
 // @llr REQ-TRAQ-SWL-76
 func (r *Req) validateLink(parent *Req) error {
 	for _, link := range r.Document.LinkSpecs {
-		if !link.Src.Re.MatchString(r.ID) {
+		if !link.Child.Re.MatchString(r.ID) {
 			// link option doesn't apply to this requirement
 			continue
 		}
 
-		if link.Src.AttrKey != "" {
-			value, present := r.Attributes[link.Src.AttrKey]
-			if !present || !link.Src.AttrVal.MatchString(value) {
+		if link.Child.AttrKey != "" {
+			value, present := r.Attributes[link.Child.AttrKey]
+			if !present || !link.Child.AttrVal.MatchString(value) {
 				// link option doesn't apply to this requirement
 				continue
 			}
 		}
 
-		if !link.Dst.Re.MatchString(parent.ID) {
+		if !link.Parent.Re.MatchString(parent.ID) {
 			// link option doesn't apply to this parent
 			continue
 		}
 
-		if link.Dst.AttrKey != "" {
-			value, present := parent.Attributes[link.Dst.AttrKey]
-			if !present || !link.Dst.AttrVal.MatchString(value) {
-				return fmt.Errorf("Requirement '%s' has invalid parent link ID '%s' with attribute value '%s'=='%s'.", r.ID, parent.ID, link.Dst.AttrKey, value)
+		if link.Parent.AttrKey != "" {
+			value, present := parent.Attributes[link.Parent.AttrKey]
+			if !present || !link.Parent.AttrVal.MatchString(value) {
+				return fmt.Errorf("Requirement '%s' has invalid parent link ID '%s' with attribute value '%s'=='%s'.", r.ID, parent.ID, link.Parent.AttrKey, value)
 			}
 		}
 

--- a/req_test.go
+++ b/req_test.go
@@ -41,13 +41,13 @@ func TestReqGraph_OrdsByPosition(t *testing.T) {
 		},
 		LinkSpecs: []config.LinkSpec{
 			{
-				Src: config.ReqSpec{
+				Child: config.ReqSpec{
 					Prefix:  config.ReqPrefix("TEST"),
 					Level:   config.ReqLevel("SWH"),
 					Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 					AttrKey: "",
 					AttrVal: regexp.MustCompile(".*")},
-				Dst: config.ReqSpec{
+				Parent: config.ReqSpec{
 					Prefix:  config.ReqPrefix("TEST"),
 					Level:   config.ReqLevel("SYS"),
 					Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),

--- a/req_test.go
+++ b/req_test.go
@@ -39,6 +39,22 @@ func TestReqGraph_OrdsByPosition(t *testing.T) {
 			Prefix: "TEST",
 			Level:  "SWH",
 		},
+		LinkSpecs: []config.LinkSpec{
+			{
+				Src: config.ReqSpec{
+					Prefix:  config.ReqPrefix("TEST"),
+					Level:   config.ReqLevel("SWH"),
+					Re:      regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
+					AttrKey: "",
+					AttrVal: regexp.MustCompile(".*")},
+				Dst: config.ReqSpec{
+					Prefix:  config.ReqPrefix("TEST"),
+					Level:   config.ReqLevel("SYS"),
+					Re:      regexp.MustCompile("REQ-TEST-SYS-(\\d+)"),
+					AttrKey: "",
+					AttrVal: regexp.MustCompile(".*")},
+			},
+		},
 		Schema: config.Schema{
 			Requirements: regexp.MustCompile("REQ-TEST-SWH-(\\d+)"),
 			Attributes:   make(map[string]*config.Attribute),
@@ -52,9 +68,11 @@ func TestReqGraph_OrdsByPosition(t *testing.T) {
 	rg.Reqs[r.ID] = r
 
 	reqIssues := rg.resolve()
-	assert.Equal(t, len(reqIssues), 1)
+	assert.Equal(t, len(reqIssues), 2)
 	assert.Equal(t, reqIssues[0].Error.Error(),
 		"Requirement `REQ-UIEM-SYS-1` in document `path/to/srd.md` does not match required regexp `REQ-TEST-SWH-(\\d+)`")
+	assert.Equal(t, reqIssues[1].Error.Error(),
+		"Requirement 'REQ-UIEM-SYS-1' has invalid parent link ID 'REQ-TEST-SYS-1'.")
 
 	reqs := rg.OrdsByPosition()
 	assert.Len(t, reqs, 2)

--- a/testdata/multiple_level_doc/TEST-100-ORD.md
+++ b/testdata/multiple_level_doc/TEST-100-ORD.md
@@ -1,0 +1,70 @@
+# ReqTraq Test File
+
+This file is used as a test input for the reqtraq tool.
+
+## Valid Requirements
+
+### REQ-TEST-SYS-1 VALID System-level requirement, no parent
+
+Must be linked from component requirements in this document.
+
+###### Attributes:
+- Parents:
+- Rationale: Rationale
+- Component Allocation: System
+
+### REQ-TEST-SYS-2 VALID System-level requirement, customer parent
+
+Must be linked from component requirements in this document.
+
+###### Attributes:
+- Parents: REQ-TEST-CST-1
+- Rationale:
+- Component Allocation: System
+
+### REQ-TEST-SYS-3 VALID Component-level requirement, no parent
+
+Component1. Must be linked from high-level requirement.
+
+###### Attributes:
+- Parents:
+- Rationale: Rationale
+- Component Allocation: Component1
+
+### REQ-TEST-SYS-4 VALID Component-level requirement, system parent
+
+Component1. Must be linked from high-level requirement.
+
+###### Attributes:
+- Parents: REQ-TEST-SYS-1
+- Rationale:
+- Component Allocation: Component1
+
+### REQ-TEST-SYS-5 VALID Component-level requirement, customer parent
+
+Component2. Must be linked from high-level requirements.
+
+###### Attributes:
+- Parents: REQ-TEST-CST-1
+- Rationale:
+- Component Allocation: Component2
+
+## Invalid Requirements
+
+### REQ-TEST-SYS-6 INVALID System-level requirement, system parent
+
+Invalid, links to a system-level requirement in this doc.
+
+###### Attributes:
+- Parents: REQ-TEST-SYS-1
+- Rationale:
+- Component Allocation: System
+
+### REQ-TEST-SYS-7 INVALID Component-level requirement, component parent
+
+Invalid, links to a component-level requirement in this doc.
+
+###### Attributes:
+- Parents: REQ-TEST-SYS-3
+- Rationale:
+- Component Allocation: Component1

--- a/testdata/multiple_level_doc/TEST-120-CST.md
+++ b/testdata/multiple_level_doc/TEST-120-CST.md
@@ -1,0 +1,12 @@
+# ReqTraq Test File
+
+This file is used as a test input for the reqtraq tool.
+
+## Valid Requirements
+
+### REQ-TEST-CST-1 VALID Customer-level requirement
+
+Can be linked from system or component requirements.
+
+###### Attributes:
+- External Reference: XYZ

--- a/testdata/multiple_level_doc/TEST-137-SRD.md
+++ b/testdata/multiple_level_doc/TEST-137-SRD.md
@@ -1,0 +1,31 @@
+# ReqTraq Test File
+
+This file is used as a test input for the reqtraq tool.
+
+## Valid Requirements
+
+### REQ-TEST-SWH-1 VALID High-level requirement, no parent
+
+Derived high-level requirement
+
+###### Attributes:
+- Parents:
+- Rationale: Rationale
+
+### REQ-TEST-SWH-2 VALID High-level requirement, component parent
+
+Links to a component-level requirement
+
+###### Attributes:
+- Parents: REQ-TEST-SYS-4
+- Rationale:
+
+## Invalid Requirements
+
+### REQ-TEST-SWH-3 INVALID High-level requirement, system parent
+
+Links to a system-level requirement
+
+###### Attributes:
+- Parents: REQ-TEST-SYS-1
+- Rationale:

--- a/testdata/multiple_level_doc/reqtraq_config.json
+++ b/testdata/multiple_level_doc/reqtraq_config.json
@@ -15,7 +15,7 @@
             "path": "TEST-100-ORD.md",
             "prefix": "TEST",
             "level": "SYS",
-            "parents": [
+            "parent": [
                 {
                     "prefix": "TEST",
                     "level": "CST"

--- a/testdata/multiple_level_doc/reqtraq_config.json
+++ b/testdata/multiple_level_doc/reqtraq_config.json
@@ -23,13 +23,13 @@
                 {
                     "prefix": "TEST",
                     "level": "SYS",
-                    "srcAttribute": {
-                        "name": "Component Allocation",
-                        "value": "^(Component1|Component2)$"
-                    },
-                    "dstAttribute": {
+                    "parentAttribute": {
                         "name": "Component Allocation",
                         "value": "^System$"
+                    },
+                    "childAttribute": {
+                        "name": "Component Allocation",
+                        "value": "^(Component1|Component2)$"
                     }
                 }
             ],
@@ -51,7 +51,7 @@
             "parent": {
                 "prefix": "TEST",
                 "level": "SYS",
-                "dstAttribute": {
+                "parentAttribute": {
                     "name": "Component Allocation",
                     "value": "^(Component1|Component2)$"
                 }

--- a/testdata/multiple_level_doc/reqtraq_config.json
+++ b/testdata/multiple_level_doc/reqtraq_config.json
@@ -1,0 +1,67 @@
+{
+    "repoName": "multiple_level_doc",
+    "documents": [
+        {
+            "path": "TEST-120-CST.md",
+            "prefix": "TEST",
+            "level": "CST",
+            "attributes": [
+                {
+                    "name": "External Reference"
+                }
+            ]
+        },
+        {
+            "path": "TEST-100-ORD.md",
+            "prefix": "TEST",
+            "level": "SYS",
+            "parents": [
+                {
+                    "prefix": "TEST",
+                    "level": "CST"
+                },
+                {
+                    "prefix": "TEST",
+                    "level": "SYS",
+                    "srcAttribute": {
+                        "name": "Component Allocation",
+                        "value": "^(Component1|Component2)$"
+                    },
+                    "dstAttribute": {
+                        "name": "Component Allocation",
+                        "value": "^System$"
+                    }
+                }
+            ],
+            "attributes": [
+                {
+                    "name": "Rationale",
+                    "required": "any"
+                },
+                {
+                    "name": "Component Allocation",
+                    "value": "^(System|Component1|Component2)$"
+                }
+            ]
+        },
+        {
+            "path": "TEST-137-SRD.md",
+            "prefix": "TEST",
+            "level": "SWH",
+            "parent": {
+                "prefix": "TEST",
+                "level": "SYS",
+                "dstAttribute": {
+                    "name": "Component Allocation",
+                    "value": "^(Component1|Component2)$"
+                }
+            },
+            "attributes": [
+                {
+                    "name": "Rationale",
+                    "required": "any"
+                }
+            ]
+        }
+    ]
+}

--- a/webapp.go
+++ b/webapp.go
@@ -154,8 +154,8 @@ var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"
 	{{ range $linkSpec := .ReqLinks }}
 		<div>
 			<div>
-				<a href="/matrix?from={{ requrl $linkSpec.Dst }}&to={{ requrl $linkSpec.Src }}">
-					{{ $linkSpec.Dst }} -> {{ $linkSpec.Src }}
+				<a href="/matrix?from={{ requrl $linkSpec.Parent }}&to={{ requrl $linkSpec.Child }}">
+					{{ $linkSpec.Parent }} -> {{ $linkSpec.Child }}
 				</a>
 			</div>
 		</div>

--- a/webapp.go
+++ b/webapp.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -56,7 +57,13 @@ func Title(str string) string {
 	return strings.Title(strings.ToLower(str))
 }
 
-var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"title": Title}).Parse(
+// ReqUrl converts a ReqSpec into a url friendly string for use in the HTML template
+// @llr REQ-TRAQ-SWL-37
+func ReqUrl(req config.ReqSpec) string {
+	return url.QueryEscape(fmt.Sprintf("%s-%s-%s-%s", req.Prefix, req.Level, req.AttrKey, req.AttrVal))
+}
+
+var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"title": Title, "requrl": ReqUrl}).Parse(
 	`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -144,11 +151,11 @@ var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"
 <h2>Trace Matrices</h2>
 <div style="display: flex;">
 	<div class="matrices">
-	{{ range $childReqSpec, $parentReqSpec := .ReqSpecLinks }}
+	{{ range $linkSpec := .ReqLinks }}
 		<div>
 			<div>
-				<a href="/matrix?from=REQ-{{ $parentReqSpec.Prefix }}-{{ $parentReqSpec.Level }}&to=REQ-{{ $childReqSpec.Prefix }}-{{ $childReqSpec.Level }}">
-					REQ-{{ $parentReqSpec.Prefix }}-{{ $parentReqSpec.Level }} -> REQ-{{ $childReqSpec.Prefix }}-{{ $childReqSpec.Level }}
+				<a href="/matrix?from={{ requrl $linkSpec.Dst }}&to={{ requrl $linkSpec.Src }}">
+					{{ $linkSpec.Dst }} -> {{ $linkSpec.Src }}
 				</a>
 			</div>
 		</div>
@@ -157,22 +164,22 @@ var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"
 	{{ range $reqSpec := .CodeLinks }}
 		<div>
 			<div>
-				<a href="/matrix?from=REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }}&to=CODE">
-					REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }} -> CODE
+				<a href="/matrix?from={{ requrl $reqSpec }}&to=CODE">
+					{{ $reqSpec }} -> CODE
 				</a>
 			</div>
 		</div>
 		<div>
 			<div>
-				<a href="/matrix?from=REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }}&to=CODE&code-type=impl">
-					REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }} -> IMPLEMENTATION
+				<a href="/matrix?from={{ requrl $reqSpec }}&to=CODE&code-type=impl">
+					{{ $reqSpec }} -> IMPLEMENTATION
 				</a>
 			</div>
 		</div>
 		<div>
 			<div>
-				<a href="/matrix?from=REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }}&to=CODE&code-type=test">
-					REQ-{{ $reqSpec.Prefix }}-{{ $reqSpec.Level }} -> TESTS
+				<a href="/matrix?from={{ requrl $reqSpec }}&to=CODE&code-type=test">
+					{{ $reqSpec }} -> TESTS
 				</a>
 			</div>
 		</div>
@@ -183,28 +190,31 @@ var indexTemplate = template.Must(template.New("index").Funcs(template.FuncMap{"
 </html>`))
 
 type indexData struct {
-	RepoName     string
-	Attributes   map[string]*config.Attribute
-	Commits      []string
-	ReqSpecLinks map[config.ReqSpec]config.ReqSpec
-	CodeLinks    []config.ReqSpec
+	RepoName   string
+	Attributes map[string]*config.Attribute
+	Commits    []string
+	ReqLinks   []config.LinkSpec
+	CodeLinks  []config.ReqSpec
 }
 
 // Gets the requirement specifier from the http request string
 // @llr REQ-TRAQ-SWL-37
 func parseReqSpecFromRequest(specString string) (config.ReqSpec, error) {
-	if !strings.HasPrefix(specString, "REQ-") {
+	rawStr, err := url.QueryUnescape(specString)
+	if err != nil {
+		return config.ReqSpec{}, err
+	}
+	parts := strings.Split(rawStr, "-")
+	if len(parts) < 2 {
 		return config.ReqSpec{}, fmt.Errorf("Invalid requirement specification `%s`", specString)
 	}
-
-	parts := strings.Split(strings.TrimPrefix(specString, "REQ-"), "-")
-	if len(parts) != 2 {
-		return config.ReqSpec{}, fmt.Errorf("Invalid requirement specification `%s`", specString)
-	}
-	return config.ReqSpec{
-		Prefix: config.ReqPrefix(parts[0]),
-		Level:  config.ReqLevel(parts[1]),
-	}, nil
+	reqSpec := config.ReqSpec{
+		Prefix:  config.ReqPrefix(parts[0]),
+		Level:   config.ReqLevel(parts[1]),
+		Re:      regexp.MustCompile(fmt.Sprintf("REQ-%s-%s-(\\d+)", parts[0], parts[1])),
+		AttrKey: parts[2],
+		AttrVal: regexp.MustCompile(parts[3])}
+	return reqSpec, nil
 }
 
 // @llr REQ-TRAQ-SWL-37
@@ -249,9 +259,9 @@ func get(w http.ResponseWriter, r *http.Request) error {
 				}
 			}
 		}
-		reqSpecLinks := reqtraqConfig.GetLinkedReqSpecs()
+		reqLinks := reqtraqConfig.GetLinkedSpecs()
 
-		return indexTemplate.Execute(w, indexData{string(repoName), attributes, commits, reqSpecLinks, codeLinks})
+		return indexTemplate.Execute(w, indexData{string(repoName), attributes, commits, reqLinks, codeLinks})
 	}
 
 	// code files linked to from reports


### PR DESCRIPTION
This change introduces the possibility of having links between requirements in the same document. This is done by allowing:
1. An attribute filter to be specified for source and/or destination of a link in the schema, this way requirements in a document can be linked as long as an attribute is used to distinguish them
2. Multiple links can be specified using "parents" (as apposed to "parent") in the schema, this is to allow requirements to still be linked to external documents

The change does not break existing configurations because the above is optional. I chose to implement a separate "parents" option in the json for simplicity, but it could also be possible to implement a custom json decoder to allow "parent" to be a single struct or array of structs. I'm open to opinions on that one =)